### PR TITLE
Add dark themed styling for game hub interface

### DIFF
--- a/game-server/public/style.css
+++ b/game-server/public/style.css
@@ -1,0 +1,373 @@
+/* Section: Theming and UI
+  This file centralizes all the styling for the application. 
+  You can easily change the theme by modifying the CSS variables below.
+*/
+
+:root {
+  --font-sans: 'Inter', sans-serif;
+  --primary-bg: #111827; /* Very Dark Blue */
+  --secondary-bg: #1f2937; /* Dark Blue-Gray */
+  --tertiary-bg: #374151; /* Medium Gray */
+  --text-primary: #f9fafb; /* Off-White */
+  --text-secondary: #9ca3af; /* Light Gray */
+  --accent-color: #4f46e5; /* Indigo */
+  --accent-hover: #4338ca; /* Darker Indigo */
+  --success-color: #10b981; /* Green */
+  --success-hover: #059669; /* Darker Green */
+  --warning-color: #f59e0b; /* Amber */
+  --warning-hover: #d97706; /* Darker Amber */
+  --border-color: #4b5563; /* Gray */
+  --shadow-color: rgba(0, 0, 0, 0.25);
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--primary-bg);
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+a {
+  color: inherit;
+}
+
+/* --- Utility Classes --- */
+.hidden {
+  display: none !important;
+}
+
+.text-gray-500 {
+  color: var(--text-secondary);
+}
+
+.container {
+  width: 100%;
+  max-width: 48rem; /* 768px */
+  padding: 2rem;
+  text-align: center;
+}
+
+.card {
+  background-color: var(--secondary-bg);
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 20px var(--shadow-color);
+  border: 1px solid var(--border-color);
+  margin-bottom: 2rem;
+}
+
+.card:last-of-type {
+  margin-bottom: 0;
+}
+
+h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  margin-bottom: 0.5rem;
+}
+
+h2 {
+  font-size: 1.875rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 0.5rem;
+}
+
+p {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+/* --- Buttons --- */
+.btn {
+  display: inline-block;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  font-size: 1.125rem;
+  text-align: center;
+  width: 100%;
+}
+
+.btn-primary {
+  background-color: var(--accent-color);
+  color: var(--text-primary);
+}
+
+.btn-primary:hover {
+  background-color: var(--accent-hover);
+  transform: translateY(-2px);
+}
+
+.btn-success {
+  background-color: var(--success-color);
+  color: var(--text-primary);
+}
+
+.btn-success:hover {
+  background-color: var(--success-hover);
+  transform: translateY(-2px);
+}
+
+.btn-warning {
+  background-color: var(--warning-color);
+  color: var(--primary-bg);
+}
+
+.btn-warning:hover {
+  background-color: var(--warning-hover);
+  transform: translateY(-2px);
+}
+
+.btn-secondary {
+  background-color: var(--tertiary-bg);
+  color: var(--text-primary);
+}
+
+.btn-secondary:hover {
+  background-color: var(--border-color);
+}
+
+.btn:disabled,
+.btn-disabled {
+  background-color: var(--tertiary-bg);
+  color: var(--text-secondary);
+  cursor: not-allowed;
+  transform: none;
+}
+
+/* --- Forms & Inputs --- */
+.input-field {
+  width: 100%;
+  background-color: var(--primary-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input-field::placeholder {
+  color: var(--text-secondary);
+}
+
+.input-field:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px var(--accent-hover);
+}
+
+/* --- Lobby List --- */
+#room-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: left;
+}
+
+.room-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: var(--tertiary-bg);
+  padding: 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 4px 10px var(--shadow-color);
+}
+
+.room-item .btn {
+  width: auto;
+  font-size: 1rem;
+}
+
+/* --- Modal Styling --- */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.modal-content {
+  background-color: var(--secondary-bg);
+  padding: 2rem;
+  border-radius: 0.75rem;
+  width: 90%;
+  max-width: 32rem; /* 512px */
+  box-shadow: 0 10px 30px var(--shadow-color);
+  border: 1px solid var(--border-color);
+  text-align: left;
+}
+
+.modal-content h1,
+.modal-content h2 {
+  border: none;
+  padding-bottom: 0;
+  margin-bottom: 0.75rem;
+}
+
+.modal-content p {
+  margin-bottom: 1rem;
+}
+
+#game-selection-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* --- Match Lobby (Staging Area) --- */
+#match-lobby {
+  text-align: left;
+}
+
+.match-lobby-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.player-card {
+  background-color: var(--tertiary-bg);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  border: 2px dashed var(--border-color);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.player-card.filled {
+  border-style: solid;
+  border-color: var(--accent-color);
+}
+
+.player-card .player-name {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.player-card .status {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.player-card .status.not-ready {
+  color: var(--warning-color);
+}
+
+.player-card .status.ready {
+  color: var(--success-color);
+}
+
+#match-lobby-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  #match-lobby-controls {
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  #match-lobby-controls .btn {
+    width: auto;
+    min-width: 10rem;
+  }
+}
+
+/* --- Game UI --- */
+#game-ui {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+#game-info-bar {
+  width: 100%;
+  max-width: 640px; /* Match game width */
+  background-color: var(--secondary-bg);
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem 0.5rem 0 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0 4px 6px var(--shadow-color);
+}
+
+#game-info-bar p {
+  margin-bottom: 0.5rem;
+  color: var(--text-primary);
+}
+
+#game-info-bar h2 {
+  margin: 0;
+  border: none;
+  padding: 0;
+}
+
+#game-container {
+  width: 100%;
+  max-width: 640px;
+  background-color: var(--primary-bg);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 10px 20px var(--shadow-color);
+  border-radius: 0 0 0.5rem 0.5rem;
+  overflow: hidden;
+  min-height: 400px;
+}
+
+#game-over-message .modal-content {
+  text-align: center;
+}
+
+#game-over-message h1 {
+  font-size: 2.25rem;
+  margin-bottom: 1.5rem;
+}
+
+/* --- Responsive Layout Adjustments --- */
+@media (max-width: 640px) {
+  body {
+    padding: 0.5rem;
+  }
+
+  .container {
+    padding: 1.5rem;
+  }
+
+  h1 {
+    font-size: 2.25rem;
+  }
+
+  h2 {
+    font-size: 1.5rem;
+  }
+
+  .match-lobby-container {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a centralized dark theme with shared CSS variables for the game hub
- style lobby cards, buttons, inputs, and modals to align with the new theme
- provide match lobby status indicators and responsive layout tweaks for the game and lobby views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a15573ec83308f977019fb1d2fa0