### PR TITLE
feat: apply retro casino theme to UI

### DIFF
--- a/game-server/public/game.js
+++ b/game-server/public/game.js
@@ -60,6 +60,11 @@ const availableGames = [
     // { id: 'chess', name: 'Chess', description: 'The ultimate game of kings.' }, // Example of a future game
 ];
 
+const playerColorSwatches = {
+    red: '#ff6b6b',
+    black: '#f5f5dc'
+};
+
 // --- UI State Management ---
 // A simple function to switch between the main UI views.
 function showUI(activeUI) {
@@ -107,7 +112,7 @@ socket.on('updateRoomList', (openRooms) => {
             </div>
             <div style="text-align: right;">
                 <p style="color: var(--text-primary); margin: 0; font-weight: 600;">${room.playerCount}/${room.maxPlayers}</p>
-                <button class="btn btn-success" onclick="joinGame('${room.roomId}')">Join</button>
+                <button class="btn btn-primary" onclick="joinGame('${room.roomId}')">Join</button>
             </div>
         </div>
     `).join('');
@@ -131,7 +136,11 @@ socket.on('gameStart', ({ gameState, players }) => {
     const myPlayer = players[myPlayerId];
     gameEls.mode.textContent = "LAN"; // This could be updated to show 'P2P' as well
     gameEls.color.textContent = myPlayer.color.toUpperCase();
-    gameEls.color.style.color = myPlayer.color;
+    const colorAccent = playerColorSwatches[myPlayer.color] || '#f5f5dc';
+    gameEls.color.style.color = colorAccent;
+    gameEls.color.style.textShadow = myPlayer.color === 'red'
+        ? '0 0 12px rgba(255, 99, 99, 0.85)'
+        : '0 0 12px rgba(255, 235, 180, 0.7)';
     updateTurnIndicator(gameState);
 
     currentPlayers = players;
@@ -264,7 +273,11 @@ function updateMatchLobby(room) {
 function updateTurnIndicator(gameState) {
     if (!gameState) return;
     gameEls.turn.textContent = `${gameState.turn.toUpperCase()}'s Turn`;
-    gameEls.turn.style.color = gameState.turn === 'red' ? '#ef4444' : '#6b7280';
+    const turnColor = playerColorSwatches[gameState.turn] || '#f5f5dc';
+    gameEls.turn.style.color = turnColor;
+    gameEls.turn.style.textShadow = gameState.turn === 'red'
+        ? '0 0 14px rgba(255, 102, 102, 0.8)'
+        : '0 0 16px rgba(255, 225, 120, 0.65)';
 }
 
 function refreshPlayerLabels() {
@@ -304,7 +317,7 @@ function startGameScene(config) {
     if (game) game.destroy(true);
     const gameConfig = {
         type: Phaser.AUTO, width: 640, height: 640,
-        parent: 'game-container', backgroundColor: '#111827',
+        parent: 'game-container', backgroundColor: '#0b3d0b',
         scene: new CheckersScene(config)
     };
     game = new Phaser.Game(gameConfig);
@@ -342,9 +355,11 @@ class CheckersScene extends Phaser.Scene {
     }
 
     drawBoard() {
+        const lightSquareColor = 0xc9d6a3;
+        const darkSquareColor = 0x0a4f0a;
         for (let y = 0; y < this.BOARD_SIZE; y++) {
             for (let x = 0; x < this.BOARD_SIZE; x++) {
-                const color = (x + y) % 2 === 0 ? 0xeeeed2 : 0x769656; // Light and dark squares
+                const color = (x + y) % 2 === 0 ? lightSquareColor : darkSquareColor;
                 this.add.rectangle(x * this.CELL_SIZE, y * this.CELL_SIZE, this.CELL_SIZE, this.CELL_SIZE, color).setOrigin(0, 0);
             }
         }
@@ -365,12 +380,13 @@ class CheckersScene extends Phaser.Scene {
                 const pieceType = this.gameState.board[y][x];
                 if (pieceType !== 0) {
                     const isKing = pieceType === 3 || pieceType === 4;
-                    const pieceColor = ([1, 3].includes(pieceType)) ? 0xdc2626 : 0x1f2937; // Red or Black
-                    const strokeColor = ([1, 3].includes(pieceType)) ? 0xf87171 : 0x4b5563;
+                    const isRedPiece = [1, 3].includes(pieceType);
+                    const pieceColor = isRedPiece ? 0xc0392b : 0x1e1b1b;
+                    const strokeColor = isRedPiece ? 0xffa07a : 0xd4af37;
                     const pieceSprite = this.add.container(x * this.CELL_SIZE + this.CELL_SIZE / 2, y * this.CELL_SIZE + this.CELL_SIZE / 2);
                     const circle = this.add.circle(0, 0, this.CELL_SIZE / 2 - 8, pieceColor).setStrokeStyle(4, strokeColor);
                     pieceSprite.add(circle);
-                    if (isKing) pieceSprite.add(this.add.text(0, 0, '👑', { fontSize: '24px' }).setOrigin(0.5));
+                    if (isKing) pieceSprite.add(this.add.text(0, 0, '👑', { fontSize: '24px', color: '#ffe066' }).setOrigin(0.5));
                     pieceSprite.setData({ gridX: x, gridY: y });
                     this.pieceSprites.add(pieceSprite);
                 }
@@ -413,7 +429,7 @@ class CheckersScene extends Phaser.Scene {
             if (sprite) {
                 const circle = sprite.list[0];
                 this.selectedPiece = { x: gridX, y: gridY, sprite: sprite, originalStroke: circle.strokeColor };
-                circle.setStrokeStyle(6, 0xffff00); // Highlight with yellow
+                circle.setStrokeStyle(6, 0xffd700); // Highlight with gold
             }
         }
     }

--- a/game-server/public/index.html
+++ b/game-server/public/index.html
@@ -22,7 +22,7 @@
                 <p>Enter a shared, secret room code to connect directly with a friend over the internet.</p>
                 <div style="display: flex; gap: 1rem;">
                     <input type="text" id="online-room-code" placeholder="Enter Room Code..." class="input-field" style="flex-grow: 1;">
-                    <button id="join-online-btn" class="btn btn-success" style="width: auto;">Join</button>
+                    <button id="join-online-btn" class="btn btn-primary" style="width: auto;">Join</button>
                 </div>
             </div>
 

--- a/game-server/public/style.css
+++ b/game-server/public/style.css
@@ -4,31 +4,34 @@
 */
 
 :root {
+  --font-display: 'Playfair Display', 'Times New Roman', serif;
   --font-sans: 'Inter', sans-serif;
-  --primary-bg: #111827; /* Very Dark Blue */
-  --secondary-bg: #1f2937; /* Dark Blue-Gray */
-  --tertiary-bg: #374151; /* Medium Gray */
-  --text-primary: #f9fafb; /* Off-White */
-  --text-secondary: #9ca3af; /* Light Gray */
-  --accent-color: #4f46e5; /* Indigo */
-  --accent-hover: #4338ca; /* Darker Indigo */
-  --success-color: #10b981; /* Green */
-  --success-hover: #059669; /* Darker Green */
-  --warning-color: #f59e0b; /* Amber */
-  --warning-hover: #d97706; /* Darker Amber */
-  --border-color: #4b5563; /* Gray */
-  --shadow-color: rgba(0, 0, 0, 0.25);
+  --primary-bg: #0b3d0b; /* Deep casino green */
+  --secondary-bg: #144d14; /* Table felt highlight */
+  --tertiary-bg: #0f3310; /* Darker green for contrast */
+  --text-primary: #f5f5dc; /* Casino parchment */
+  --text-secondary: #dcdcb5; /* Muted parchment */
+  --accent-color: #b8860b; /* Goldenrod */
+  --accent-hover: #916e0e; /* Deep gold */
+  --success-color: #e03030; /* Card-table red */
+  --success-hover: #c02020; /* Deep red */
+  --warning-color: #ffa500; /* Warm amber */
+  --warning-hover: #cc8400; /* Burnished amber */
+  --ready-color: #4fdc7c; /* Emerald ready indicator */
+  --border-color: #86592d; /* Antique brass */
+  --shadow-color: rgba(0, 0, 0, 0.5);
 }
 
 body {
-  font-family: var(--font-sans);
-  background-color: var(--primary-bg);
+  font-family: var(--font-display);
+  background: radial-gradient(circle at center, #0e4d0e 0%, var(--primary-bg) 70%, #062006 100%);
   color: var(--text-primary);
   display: flex;
   align-items: center;
   justify-content: center;
   min-height: 100vh;
   padding: 1rem;
+  background-attachment: fixed;
 }
 
 a {
@@ -52,12 +55,14 @@ a {
 }
 
 .card {
-  background-color: var(--secondary-bg);
+  background: linear-gradient(135deg, rgba(24, 102, 24, 0.95), rgba(9, 51, 9, 0.95));
   padding: 1.5rem;
   border-radius: 0.75rem;
-  box-shadow: 0 10px 20px var(--shadow-color);
+  box-shadow: 0 18px 40px var(--shadow-color);
   border: 1px solid var(--border-color);
   margin-bottom: 2rem;
+  position: relative;
+  overflow: hidden;
 }
 
 .card:last-of-type {
@@ -68,14 +73,17 @@ h1 {
   font-size: 3rem;
   font-weight: 800;
   margin-bottom: 0.5rem;
+  color: var(--accent-color);
+  text-shadow: 3px 3px 8px rgba(0, 0, 0, 0.8);
 }
 
 h2 {
   font-size: 1.875rem;
   font-weight: 700;
   margin-bottom: 1rem;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid rgba(134, 89, 45, 0.6);
   padding-bottom: 0.5rem;
+  text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.75);
 }
 
 p {
@@ -96,45 +104,54 @@ p {
   font-size: 1.125rem;
   text-align: center;
   width: 100%;
+  font-family: var(--font-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
 }
 
 .btn-primary {
-  background-color: var(--accent-color);
-  color: var(--text-primary);
+  background: linear-gradient(to bottom, #d9a520, var(--accent-color));
+  color: #fff5d7;
+  border: 1px solid rgba(0, 0, 0, 0.2);
 }
 
 .btn-primary:hover {
-  background-color: var(--accent-hover);
+  background: linear-gradient(to bottom, #e0b93a, var(--accent-hover));
   transform: translateY(-2px);
 }
 
 .btn-success {
-  background-color: var(--success-color);
-  color: var(--text-primary);
+  background: linear-gradient(to bottom, #f45f5f, var(--success-color));
+  color: #fff5f5;
+  border: 1px solid rgba(0, 0, 0, 0.2);
 }
 
 .btn-success:hover {
-  background-color: var(--success-hover);
+  background: linear-gradient(to bottom, #ff7676, var(--success-hover));
   transform: translateY(-2px);
 }
 
 .btn-warning {
-  background-color: var(--warning-color);
-  color: var(--primary-bg);
+  background: linear-gradient(to bottom, #ffc861, var(--warning-color));
+  color: #3b1c00;
+  border: 1px solid rgba(0, 0, 0, 0.2);
 }
 
 .btn-warning:hover {
-  background-color: var(--warning-hover);
+  background: linear-gradient(to bottom, #ffd684, var(--warning-hover));
   transform: translateY(-2px);
 }
 
 .btn-secondary {
-  background-color: var(--tertiary-bg);
+  background: linear-gradient(to bottom, rgba(34, 82, 34, 0.95), rgba(12, 40, 12, 0.95));
   color: var(--text-primary);
+  border: 1px solid rgba(0, 0, 0, 0.25);
 }
 
 .btn-secondary:hover {
-  background-color: var(--border-color);
+  background: linear-gradient(to bottom, rgba(42, 102, 42, 0.95), rgba(15, 46, 15, 0.95));
 }
 
 .btn:disabled,
@@ -143,14 +160,15 @@ p {
   color: var(--text-secondary);
   cursor: not-allowed;
   transform: none;
+  box-shadow: none;
 }
 
 /* --- Forms & Inputs --- */
 .input-field {
   width: 100%;
-  background-color: var(--primary-bg);
+  background-color: rgba(6, 32, 6, 0.85);
   color: var(--text-primary);
-  border: 1px solid var(--border-color);
+  border: 1px solid rgba(134, 89, 45, 0.6);
   padding: 0.75rem;
   border-radius: 0.5rem;
   font-size: 1rem;
@@ -164,7 +182,7 @@ p {
 .input-field:focus {
   outline: none;
   border-color: var(--accent-color);
-  box-shadow: 0 0 0 2px var(--accent-hover);
+  box-shadow: 0 0 0 2px rgba(184, 134, 11, 0.4);
 }
 
 /* --- Lobby List --- */
@@ -179,11 +197,11 @@ p {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background-color: var(--tertiary-bg);
+  background: linear-gradient(135deg, rgba(26, 78, 26, 0.9), rgba(10, 43, 10, 0.9));
   padding: 1rem;
   border-radius: 0.5rem;
-  border: 1px solid var(--border-color);
-  box-shadow: 0 4px 10px var(--shadow-color);
+  border: 1px solid rgba(134, 89, 45, 0.6);
+  box-shadow: 0 12px 24px var(--shadow-color);
 }
 
 .room-item .btn {
@@ -207,13 +225,13 @@ p {
 }
 
 .modal-content {
-  background-color: var(--secondary-bg);
+  background: linear-gradient(135deg, rgba(30, 96, 30, 0.95), rgba(11, 53, 11, 0.95));
   padding: 2rem;
   border-radius: 0.75rem;
   width: 90%;
   max-width: 32rem; /* 512px */
-  box-shadow: 0 10px 30px var(--shadow-color);
-  border: 1px solid var(--border-color);
+  box-shadow: 0 24px 40px var(--shadow-color);
+  border: 1px solid rgba(134, 89, 45, 0.8);
   text-align: left;
 }
 
@@ -247,11 +265,11 @@ p {
 }
 
 .player-card {
-  background-color: var(--tertiary-bg);
+  background: linear-gradient(145deg, rgba(26, 88, 26, 0.95), rgba(10, 40, 10, 0.95));
   border-radius: 0.5rem;
   padding: 1.5rem;
-  border: 2px dashed var(--border-color);
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+  border: 2px dashed rgba(184, 134, 11, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.35), 0 14px 28px rgba(0, 0, 0, 0.45);
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -259,7 +277,7 @@ p {
 
 .player-card.filled {
   border-style: solid;
-  border-color: var(--accent-color);
+  border-color: rgba(184, 134, 11, 0.85);
 }
 
 .player-card .player-name {
@@ -270,14 +288,15 @@ p {
 .player-card .status {
   font-size: 1.25rem;
   font-weight: 600;
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.6);
 }
 
 .player-card .status.not-ready {
-  color: var(--warning-color);
+  color: var(--success-color);
 }
 
 .player-card .status.ready {
-  color: var(--success-color);
+  color: var(--ready-color);
 }
 
 #match-lobby-controls {
@@ -309,13 +328,14 @@ p {
 #game-info-bar {
   width: 100%;
   max-width: 640px; /* Match game width */
-  background-color: var(--secondary-bg);
+  background: linear-gradient(135deg, rgba(30, 96, 30, 0.95), rgba(9, 43, 9, 0.95));
   padding: 0.75rem 1.5rem;
   border-radius: 0.5rem 0.5rem 0 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  box-shadow: 0 4px 6px var(--shadow-color);
+  box-shadow: 0 14px 26px var(--shadow-color);
+  border: 1px solid rgba(134, 89, 45, 0.6);
 }
 
 #game-info-bar p {
@@ -327,34 +347,44 @@ p {
   margin: 0;
   border: none;
   padding: 0;
+  color: var(--accent-color);
+  text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.85);
 }
 
 #scoreboard {
-  background-color: var(--secondary-bg);
+  background: linear-gradient(135deg, rgba(33, 102, 33, 0.95), rgba(8, 35, 8, 0.95));
   padding: 0.5rem 1rem;
   border-radius: 0.5rem;
   max-width: 640px;
   width: 100%;
   margin: 0 auto 1rem auto;
-  box-shadow: 0 4px 6px var(--shadow-color);
+  box-shadow: 0 12px 22px var(--shadow-color);
+  border: 1px solid rgba(134, 89, 45, 0.55);
 }
 
 #scoreboard p {
   margin: 0;
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--accent-color);
   text-align: center;
+  text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.75);
 }
 
 #game-container {
   width: 100%;
   max-width: 640px;
-  background-color: var(--primary-bg);
-  border: 1px solid var(--border-color);
-  box-shadow: 0 10px 20px var(--shadow-color);
+  background: radial-gradient(circle at center, rgba(23, 82, 23, 0.95), rgba(5, 26, 5, 0.95));
+  border: 1px solid rgba(134, 89, 45, 0.6);
+  box-shadow: 0 24px 40px var(--shadow-color);
   border-radius: 0 0 0.5rem 0.5rem;
   overflow: hidden;
   min-height: 400px;
+}
+
+#turn-indicator {
+  color: var(--text-primary);
+  text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.85);
+  letter-spacing: 0.05em;
 }
 
 #game-over-message .modal-content {


### PR DESCRIPTION
## Summary
- restyle the public UI with casino-inspired greens, golds, and gradients plus updated typography
- refresh lobby controls and status colors, including a golden primary button and clearer ready indicators
- recolor the Phaser checkers board and pieces to match the new theme with improved turn highlighting

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d6be6125548330a64fa51d694c291f