### PR TITLE
Add Windows and CachyOS helper scripts for server setup

### DIFF
--- a/game-server/README.md
+++ b/game-server/README.md
@@ -14,6 +14,7 @@ This project is a lightweight, self-hosted web server for playing classic multip
     ```
     npm install
     ```
+3.  **CachyOS users:** run `./install_cachyos.sh` to automatically install Node.js (if needed) and install the project dependencies.
 
 ## Running the Server
 
@@ -21,4 +22,9 @@ This project is a lightweight, self-hosted web server for playing classic multip
     ```
     npm start
     ```
+    - CachyOS users can alternatively run `./run_cachyos.sh` to verify dependencies and launch the server automatically.
 2.  The server will now be running. You can access the game hub by opening a web browser and going to `http://[SERVER-IP-ADDRESS]:8081`. You can find your server's local IP address in your network settings. If you are on the server machine itself, you can use `http://localhost:8081`.
+
+## Windows Shortcut
+
+- Windows users can double-click `run_windows.bat` to check for Node.js, install dependencies, and start the server automatically.

--- a/game-server/install_cachyos.sh
+++ b/game-server/install_cachyos.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+printf '=== HomeGameServer CachyOS Installer ===\n'
+
+if ! command -v node >/dev/null 2>&1; then
+  printf 'Node.js is not installed. Installing via pacman (requires sudo)...\n'
+  sudo pacman -Sy --needed nodejs npm
+else
+  printf 'Node.js already installed.\n'
+fi
+
+printf 'Installing npm dependencies...\n'
+npm install
+printf 'Dependencies installed successfully.\n'
+printf 'You can now run ./run_cachyos.sh to start the server.\n'

--- a/game-server/run_cachyos.sh
+++ b/game-server/run_cachyos.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+printf '=== HomeGameServer Runner ===\n'
+
+if ! command -v node >/dev/null 2>&1; then
+  printf 'ERROR: Node.js is not installed or not in PATH.\n'
+  printf 'Please run ./install_cachyos.sh first.\n'
+  exit 1
+fi
+
+if [ ! -d node_modules ]; then
+  printf 'Dependencies not installed. Running npm install...\n'
+  npm install
+fi
+
+printf 'Starting the game server...\n'
+npm start

--- a/game-server/run_windows.bat
+++ b/game-server/run_windows.bat
@@ -1,0 +1,20 @@
+@echo off
+cd /d "%~dp0"
+echo === HomeGameServer Setup ===
+echo Checking for Node.js and npm...
+npm -v >NUL 2>NUL
+IF %ERRORLEVEL% NEQ 0 (
+    echo ERROR: Node.js is not installed or not in PATH.
+    echo Please install Node.js from https://nodejs.org and try again.
+    pause
+    exit /B 1
+)
+echo Installing dependencies...
+npm install
+IF %ERRORLEVEL% NEQ 0 (
+    echo Failed to install npm packages. Please check for errors.
+    pause
+    exit /B 1
+)
+echo Starting the game server...
+npm start


### PR DESCRIPTION
## Summary
- add a Windows batch script that checks for Node.js, installs npm dependencies, and launches the server
- add CachyOS installer and run scripts to automate pacman dependency setup and starting the server
- document the new scripts in the README for quick discovery

## Testing
- not run (utility scripts only)


------
https://chatgpt.com/codex/tasks/task_e_68d6c05b91b08330a70ffbe3779445d0