### PR TITLE
Include game mode details in game start event

### DIFF
--- a/game-server/public/game.js
+++ b/game-server/public/game.js
@@ -236,10 +236,10 @@ socket.on('roomStateUpdate', (room) => {
 });
 
 // Triggered by the server when the host starts the game.
-socket.on('gameStart', ({ gameState, players }) => {
+socket.on('gameStart', ({ gameState, players, mode }) => {
     showUI(ui.gameUI);
     const myPlayer = players[myPlayerId];
-    gameEls.mode.textContent = "LAN"; // This could be updated to show 'P2P' as well
+    gameEls.mode.textContent = (mode === 'p2p') ? 'Online (P2P)' : 'LAN';
     gameEls.color.textContent = myPlayer.color.toUpperCase();
     const colorAccent = playerColorSwatches[myPlayer.color] || '#f5f5dc';
     gameEls.color.style.color = colorAccent;

--- a/game-server/server.js
+++ b/game-server/server.js
@@ -115,7 +115,7 @@ io.on('connection', (socket) => {
                  room.score = { red: 0, black: 0 };
                  room.round = 1;
                  room.gameState = initializeCheckersState(room.players, room.round, room.score);
-                 io.to(roomId).emit('gameStart', { gameState: room.gameState, players: room.players });
+                 io.to(roomId).emit('gameStart', { gameState: room.gameState, players: room.players, mode: room.mode });
             } else {
                  socket.emit('error', 'Cannot start: Not all players are ready or the room is not full.');
             }


### PR DESCRIPTION
## Summary
- include the room mode in the gameStart payload emitted by the server
- update the client to render the correct mode label based on the incoming mode value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d76ca340cc8330ae1960f068abd220