### PR TITLE
Simplify winner name display

### DIFF
--- a/game-server/server.js
+++ b/game-server/server.js
@@ -135,9 +135,7 @@ io.on('connection', (socket) => {
             const winner = checkForWinner(room.gameState);
             if (winner) {
                 const winnerColor = winner;
-                const winnerSocketId = Object.keys(room.players).find(pid => room.players[pid].color === winnerColor);
-                const winnerPlayer = winnerSocketId ? room.players[winnerSocketId] : null;
-                const winnerName = winnerPlayer?.username || winnerPlayer?.name || winnerPlayer?.displayName || winnerColor;
+                const winnerName = winnerColor ? winnerColor.toUpperCase() : 'Unknown';
 
                 room.score[winnerColor] += 1;
                 room.gameState.score = { ...room.score };


### PR DESCRIPTION
## Summary
- remove username fallbacks when determining the winner label and default to the winning color name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d76d88e86883308626e1df101b9694