### PR TITLE
feat: restyle lobby with Windows 2000 theme

### DIFF
--- a/game-server/public/images/PLACE DEFAULT PNG HERE.txt
+++ b/game-server/public/images/PLACE DEFAULT PNG HERE.txt
@@ -1,0 +1,1 @@
+Place your default avatar image in this directory and name it "default-avatar.png".

--- a/game-server/public/index.html
+++ b/game-server/public/index.html
@@ -1,114 +1,176 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Game Hub</title>
-    <!-- Link to the new theme file -->
+    <title>Game Hub - Windows 2000 Edition</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-    <!-- Main Container -->
-    <div class="container">
-        
-        <!-- Main Lobby Selection -->
-        <div id="main-lobby">
-            <h1>Game Hub</h1>
-            <p>A lightweight, local-first platform for classic games.</p>
-
-            <p id="name-greeting" class="name-greeting">Welcome, <span id="player-name-preview">Guest</span>!</p>
-
-            <div class="name-row">
-                <input id="displayNameInput" placeholder="Your display name" maxlength="24">
-                <button id="saveDisplayNameBtn" class="btn btn-secondary">Save Name</button>
-            </div>
-
-            <div class="card identity-card">
-                <h2>Set Your Name</h2>
-                <p>Choose the name that will appear in match lobbies and scoreboards.</p>
-                <div class="name-input-row">
-                    <input type="text" id="player-name-input" class="input-field" placeholder="Enter your display name..." maxlength="24">
-                    <button id="save-name-btn" class="btn btn-secondary name-save-btn">Save Name</button>
-                </div>
-                <p id="name-status" class="name-status hidden"></p>
-            </div>
-
-            <div class="card">
-                <h2>Play Online (P2P)</h2>
-                <p>Enter a shared, secret room code to connect directly with a friend over the internet.</p>
-                <div style="display: flex; gap: 1rem;">
-                    <input type="text" id="online-room-code" placeholder="Enter Room Code..." class="input-field" style="flex-grow: 1;">
-                    <button id="join-online-btn" class="btn btn-primary" style="width: auto;">Join</button>
-                </div>
-            </div>
-
-            <div class="card">
-                <h2>Play on Local WiFi</h2>
-                <p>Create or join a game with others on the same network.</p>
-                <button id="show-create-game-modal-btn" class="btn btn-primary" style="margin-bottom: 2rem;">Create New LAN Game</button>
-                
-                <h2>Available LAN Games</h2>
-                <div id="room-list">
-                    <p class="text-gray-500">No open games found. Create one!</p>
-                </div>
-            </div>
+    <div class="profile-corner classic-raised">
+        <img src="/uploads/profiles/avatar.webp" alt="Profile" class="profile-avatar" onerror="this.src='/images/default-avatar.png'">
+        <div class="profile-stats">
+            <div class="profile-name">Guest</div>
+            <div class="profile-meta">Wins: 0 | Level: 1</div>
         </div>
-        
-        <!-- Match Lobby (Staging Area) -->
-        <div id="match-lobby" class="hidden">
-            <h1 id="match-lobby-gametype">Game Lobby</h1>
-            <p>The game will begin when the host starts the match.</p>
-
-            <div class="card">
-                <div class="match-lobby-container">
-                    <div id="player1-card" class="player-card">
-                        <p class="player-name">Player 1 (Host)</p>
-                        <p id="player1-status" class="status not-ready">Not Ready</p>
-                    </div>
-                    <div id="player2-card" class="player-card">
-                        <p class="player-name">Waiting for Player...</p>
-                        <p id="player2-status" class="status not-ready">Not Ready</p>
-                    </div>
-                </div>
-                <div id="match-lobby-controls">
-                    <button id="ready-btn" class="btn btn-warning">Ready Up</button>
-                    <button id="start-game-btn" class="btn btn-primary hidden" disabled>Start Game</button>
-                </div>
-            </div>
-        </div>
-
-        <!-- Main Game UI -->
-        <div id="game-ui" class="hidden">
-            <div id="game-info-bar">
-                <div>
-                     <p>Mode: <b id="game-mode"></b></p>
-                     <p>Your Color: <b id="player-color"></b></p>
-                </div>
-                <h2 id="turn-indicator" style="margin: 0; border: none; padding: 0;"></h2>
-            </div>
-            <div id="scoreboard" class="scoreboard hidden">
-                <p id="score-text">Red: 0 – Black: 0</p>
-            </div>
-            <div id="game-container"></div>
-            <div id="game-over-message" class="modal-overlay hidden">
-                <div class="modal-content">
-                    <h1 id="winner-text"></h1>
-                    <button onclick="location.reload()" class="btn btn-primary">Back to Lobby</button>
-                </div>
-            </div>
+        <div class="profile-dropdown classic-raised">
+            <button class="profile-menu-item" type="button">View Profile</button>
+            <button class="profile-menu-item" type="button">Change Avatar</button>
+            <button class="profile-menu-item" type="button">Sign In</button>
         </div>
     </div>
 
-    <!-- Create Game Modal -->
-    <div id="create-game-modal" class="modal-overlay hidden">
-        <div class="modal-content">
-            <h2>Create a New Game</h2>
-            <p>Choose a game to host on the local network.</p>
-            <div id="game-selection-list">
-                <!-- Game options will be dynamically inserted here by game.js -->
+    <div class="app-container">
+        <header class="header">
+            <div class="window">
+                <div class="title-bar">
+                    <span class="title-bar-text">Game Hub Control Center</span>
+                    <div class="title-bar-controls">
+                        <span class="title-bar-btn" aria-label="Minimize">_</span>
+                        <span class="title-bar-btn" aria-label="Maximize">□</span>
+                        <span class="title-bar-btn" aria-label="Close">×</span>
+                    </div>
+                </div>
+                <div class="window-body">
+                    <p class="intro-text">A lightweight, local-first platform for classic games with authentic Windows 2000 styling.</p>
+                </div>
             </div>
-            <button id="close-modal-btn" class="btn btn-secondary" style="margin-top: 1.5rem;">Cancel</button>
+        </header>
+
+        <main class="left-panels">
+            <section id="main-lobby" class="window">
+                <div class="title-bar">
+                    <span class="title-bar-text">Player Setup &amp; Quick Actions</span>
+                </div>
+                <div class="window-body">
+                    <h1 class="app-title">Game Hub</h1>
+                    <p class="tagline">Welcome to the modernized retro experience.</p>
+
+                    <p id="name-greeting" class="name-greeting">Welcome, <span id="player-name-preview">Guest</span>!</p>
+
+                    <div class="name-row">
+                        <input id="displayNameInput" class="input-field" placeholder="Your display name" maxlength="24">
+                        <button id="saveDisplayNameBtn" class="btn">Save Name</button>
+                    </div>
+
+                    <div class="window-section classic-raised">
+                        <h2>Identity</h2>
+                        <p>Choose the name that will appear in match lobbies and scoreboards.</p>
+                        <div class="name-input-row">
+                            <input type="text" id="player-name-input" class="input-field" placeholder="Enter your display name..." maxlength="24">
+                            <button id="save-name-btn" class="btn">Save Name</button>
+                        </div>
+                        <p id="name-status" class="name-status hidden"></p>
+                    </div>
+
+                    <div class="window-section classic-raised">
+                        <h2>Play Online (P2P)</h2>
+                        <p>Enter a shared, secret room code to connect directly with a friend over the internet.</p>
+                        <div class="input-row">
+                            <input type="text" id="online-room-code" placeholder="Enter Room Code..." class="input-field">
+                            <button id="join-online-btn" class="btn btn-primary">Join</button>
+                        </div>
+                    </div>
+
+                    <div class="window-section classic-raised">
+                        <h2>Play on Local WiFi</h2>
+                        <p>Create or join a game with others on the same network.</p>
+                        <button id="show-create-game-modal-btn" class="btn btn-primary">Create New LAN Game</button>
+                    </div>
+                </div>
+            </section>
+
+            <section id="match-lobby" class="window hidden">
+                <div class="title-bar">
+                    <span class="title-bar-text">Match Lobby</span>
+                </div>
+                <div class="window-body">
+                    <h1 id="match-lobby-gametype" class="window-heading">Game Lobby</h1>
+                    <p>The game will begin when the host starts the match.</p>
+
+                    <div class="match-lobby classic-sunken">
+                        <div class="player-card classic-raised" id="player1-card">
+                            <p class="player-name">Player 1 (Host)</p>
+                            <p id="player1-status" class="status not-ready">Not Ready</p>
+                        </div>
+                        <div class="player-card classic-raised" id="player2-card">
+                            <p class="player-name">Waiting for Player...</p>
+                            <p id="player2-status" class="status not-ready">Not Ready</p>
+                        </div>
+                    </div>
+                    <div class="match-controls">
+                        <button id="ready-btn" class="btn btn-warning">Ready Up</button>
+                        <button id="start-game-btn" class="btn btn-primary hidden" disabled>Start Game</button>
+                    </div>
+                </div>
+            </section>
+
+            <section id="game-ui" class="window hidden">
+                <div class="title-bar">
+                    <span class="title-bar-text">Game Session</span>
+                </div>
+                <div class="window-body">
+                    <div id="game-info-bar" class="classic-raised">
+                        <div>
+                            <p>Mode: <b id="game-mode"></b></p>
+                            <p>Your Color: <b id="player-color"></b></p>
+                        </div>
+                        <h2 id="turn-indicator"></h2>
+                    </div>
+                    <div id="scoreboard" class="scoreboard classic-raised hidden">
+                        <p id="score-text">Red: 0 – Black: 0</p>
+                    </div>
+                    <div id="game-container" class="classic-sunken"></div>
+                    <div id="game-over-message" class="modal-overlay hidden">
+                        <div class="modal-content classic-raised">
+                            <h1 id="winner-text"></h1>
+                            <button onclick="location.reload()" class="btn btn-primary">Back to Lobby</button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <aside class="lobby-list">
+            <div class="window" style="height: 100%;">
+                <div class="title-bar">
+                    <span class="title-bar-text">Available LAN Games</span>
+                </div>
+                <div class="window-body lobby-body">
+                    <div class="classic-sunken lobby-scroll">
+                        <div id="room-list">
+                            <p class="text-muted">No open games found. Create one!</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </aside>
+
+        <footer class="footer">
+            <div class="window">
+                <div class="title-bar">
+                    <span class="title-bar-text">Server Status</span>
+                </div>
+                <div class="window-body status-body">
+                    <div class="status-indicator online">Online</div>
+                    <div class="status-message">Local multiplayer services are running.</div>
+                </div>
+            </div>
+        </footer>
+    </div>
+
+    <div id="create-game-modal" class="modal-overlay hidden">
+        <div class="modal-content classic-raised">
+            <div class="title-bar">
+                <span class="title-bar-text">Create a New Game</span>
+            </div>
+            <div class="modal-body">
+                <p>Choose a game to host on the local network.</p>
+                <div id="game-selection-list" class="selection-list"></div>
+                <div class="modal-actions">
+                    <button id="close-modal-btn" class="btn">Cancel</button>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/game-server/public/style.css
+++ b/game-server/public/style.css
@@ -1,462 +1,491 @@
-/* Section: Theming and UI
-  This file centralizes all the styling for the application. 
-  You can easily change the theme by modifying the CSS variables below.
-*/
-
 :root {
-  --font-display: 'Playfair Display', 'Times New Roman', serif;
-  --font-sans: 'Inter', sans-serif;
-  --primary-bg: #0b3d0b; /* Deep casino green */
-  --secondary-bg: #144d14; /* Table felt highlight */
-  --tertiary-bg: #0f3310; /* Darker green for contrast */
-  --text-primary: #f5f5dc; /* Casino parchment */
-  --text-secondary: #dcdcb5; /* Muted parchment */
-  --accent-color: #b8860b; /* Goldenrod */
-  --accent-hover: #916e0e; /* Deep gold */
-  --success-color: #e03030; /* Card-table red */
-  --success-hover: #c02020; /* Deep red */
-  --warning-color: #ffa500; /* Warm amber */
-  --warning-hover: #cc8400; /* Burnished amber */
-  --ready-color: #4fdc7c; /* Emerald ready indicator */
-  --border-color: #86592d; /* Antique brass */
-  --shadow-color: rgba(0, 0, 0, 0.5);
+  --win2k-desktop-blue: #3B6EA5;
+  --win2k-control-face: #C0C0C0;
+  --win2k-button-face: #ECE9D8;
+  --win2k-button-highlight: #FFFFFF;
+  --win2k-button-shadow: #ACA899;
+  --win2k-window-frame: #D4D0C8;
+  --win2k-border-dark: #0a0a0a;
+  --win2k-border-light: #ffffff;
+  --win2k-border-mid: #808080;
+  --win2k-border-mid-light: #dfdfdf;
+  --win2k-title-gradient-start: #0a5d8c;
+  --win2k-title-gradient-end: #1084d0;
+  --win2k-text: #000000;
+  --win2k-muted: #4a4a4a;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
-  font-family: var(--font-display);
-  background: radial-gradient(circle at center, #0e4d0e 0%, var(--primary-bg) 70%, #062006 100%);
-  color: var(--text-primary);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  font-family: "MS Sans Serif", "Microsoft Sans Serif", Tahoma, sans-serif;
+  font-size: 11px;
+  background: linear-gradient(180deg, var(--win2k-desktop-blue) 0%, #24527a 40%, #0b2b47 100%);
+  color: var(--win2k-text);
+  margin: 0;
   min-height: 100vh;
-  padding: 1rem;
-  background-attachment: fixed;
 }
 
 a {
   color: inherit;
+  text-decoration: none;
 }
 
-/* --- Utility Classes --- */
 .hidden {
   display: none !important;
 }
 
-.text-gray-500 {
-  color: var(--text-secondary);
+.text-muted {
+  color: var(--win2k-muted);
 }
 
-.container {
-  width: 100%;
-  max-width: 48rem; /* 768px */
-  padding: 2rem;
-  text-align: center;
+.app-container {
+  display: grid;
+  grid-template-columns: 2fr 1.2fr;
+  grid-template-rows: auto 1fr auto;
+  gap: 4px;
+  padding: 12px;
+  min-height: 100vh;
 }
 
-.card {
-  background: linear-gradient(135deg, rgba(24, 102, 24, 0.95), rgba(9, 51, 9, 0.95));
-  padding: 1.5rem;
-  border-radius: 0.75rem;
-  box-shadow: 0 18px 40px var(--shadow-color);
-  border: 1px solid var(--border-color);
-  margin-bottom: 2rem;
-  position: relative;
-  overflow: hidden;
+.header {
+  grid-column: 1 / -1;
 }
 
-.card:last-of-type {
-  margin-bottom: 0;
+.left-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-h1 {
-  font-size: 3rem;
-  font-weight: 800;
-  margin-bottom: 0.5rem;
-  color: var(--accent-color);
-  text-shadow: 3px 3px 8px rgba(0, 0, 0, 0.8);
+.lobby-list {
+  display: flex;
+  flex-direction: column;
 }
 
-h2 {
-  font-size: 1.875rem;
-  font-weight: 700;
-  margin-bottom: 1rem;
-  border-bottom: 1px solid rgba(134, 89, 45, 0.6);
-  padding-bottom: 0.5rem;
-  text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.75);
+.footer {
+  grid-column: 1 / -1;
 }
 
-p {
-  color: var(--text-secondary);
-  margin-bottom: 1.5rem;
-  line-height: 1.6;
+.window {
+  background: var(--win2k-control-face);
+  padding: 2px;
+  box-shadow:
+    inset -1px -1px var(--win2k-border-dark),
+    inset 1px 1px var(--win2k-border-mid-light),
+    inset -2px -2px var(--win2k-border-mid),
+    inset 2px 2px var(--win2k-border-light);
+}
+
+.title-bar {
+  background: linear-gradient(90deg, var(--win2k-title-gradient-start), var(--win2k-title-gradient-end));
+  color: #ffffff;
+  font-weight: bold;
+  padding: 2px 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  line-height: 1.2;
+}
+
+.title-bar-text {
+  font-size: 12px;
+}
+
+.title-bar-controls {
+  display: flex;
+  gap: 2px;
+}
+
+.title-bar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 14px;
+  background: var(--win2k-button-face);
+  border: 1px solid var(--win2k-border-dark);
+  box-shadow:
+    inset -1px -1px var(--win2k-border-dark),
+    inset 1px 1px var(--win2k-border-light);
+  font-size: 10px;
+}
+
+.window-body {
+  background: var(--win2k-control-face);
+  padding: 10px;
+  border: 1px solid var(--win2k-window-frame);
+}
+
+.classic-raised {
+  box-shadow:
+    inset -1px -1px var(--win2k-border-dark),
+    inset 1px 1px var(--win2k-border-light),
+    inset -2px -2px var(--win2k-border-mid),
+    inset 2px 2px var(--win2k-border-mid-light);
+  background: var(--win2k-button-face);
+}
+
+.classic-sunken {
+  box-shadow:
+    inset -1px -1px var(--win2k-border-light),
+    inset 1px 1px var(--win2k-border-dark),
+    inset -2px -2px var(--win2k-border-mid-light),
+    inset 2px 2px var(--win2k-border-mid);
+  background: #ffffff;
+}
+
+.profile-corner {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background: var(--win2k-control-face);
+  padding: 6px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 1000;
+  border: 2px outset var(--win2k-control-face);
+}
+
+.profile-avatar {
+  width: 32px;
+  height: 32px;
+  border: 1px inset var(--win2k-border-mid);
+  background: #ffffff;
+  object-fit: cover;
+}
+
+.profile-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.profile-name {
+  font-weight: bold;
+}
+
+.profile-dropdown {
+  display: none;
+  position: absolute;
+  top: calc(100% + 2px);
+  right: 0;
+  min-width: 160px;
+  background: var(--win2k-control-face);
+  border: 2px outset var(--win2k-control-face);
+  flex-direction: column;
+}
+
+.profile-corner:hover .profile-dropdown {
+  display: flex;
+}
+
+.profile-menu-item {
+  font-family: inherit;
+  font-size: 11px;
+  padding: 4px 8px;
+  text-align: left;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.profile-menu-item:hover {
+  background: #316ac5;
+  color: #ffffff;
+}
+
+.intro-text {
+  margin: 6px 0 0;
+}
+
+.app-title {
+  font-size: 24px;
+  margin: 6px 0 4px;
+}
+
+.tagline {
+  margin: 0 0 12px;
+  color: var(--win2k-muted);
 }
 
 .name-greeting {
-  font-family: var(--font-sans);
-  color: var(--text-secondary);
-  margin-bottom: 1.5rem;
-  font-size: 1.1rem;
+  margin: 0 0 10px;
 }
 
-.identity-card {
-  margin-bottom: 2.5rem;
-}
-
-.name-input-row {
+.name-row,
+.name-input-row,
+.input-row {
   display: flex;
+  gap: 8px;
   flex-wrap: wrap;
-  gap: 1rem;
-  align-items: center;
+  margin-bottom: 12px;
 }
 
-.name-input-row .input-field {
-  flex: 1 1 14rem;
-}
-
-.name-save-btn {
-  width: auto;
-  min-width: 10rem;
-}
-
-.name-status {
-  font-family: var(--font-sans);
-  color: var(--accent-color);
-  margin-top: 0.75rem;
-  font-size: 0.95rem;
-}
-
-.name-status.success {
-  color: var(--ready-color);
-}
-
-.name-status.error {
-  color: var(--success-color);
-}
-
-/* --- Buttons --- */
-.btn {
-  display: inline-block;
-  font-weight: 600;
-  padding: 0.75rem 1.5rem;
-  border-radius: 0.5rem;
-  border: none;
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
-  font-size: 1.125rem;
-  text-align: center;
-  width: 100%;
-  font-family: var(--font-sans);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.45);
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
-}
-
-.btn-primary {
-  background: linear-gradient(to bottom, #d9a520, var(--accent-color));
-  color: #fff5d7;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-}
-
-.btn-primary:hover {
-  background: linear-gradient(to bottom, #e0b93a, var(--accent-hover));
-  transform: translateY(-2px);
-}
-
-.btn-success {
-  background: linear-gradient(to bottom, #f45f5f, var(--success-color));
-  color: #fff5f5;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-}
-
-.btn-success:hover {
-  background: linear-gradient(to bottom, #ff7676, var(--success-hover));
-  transform: translateY(-2px);
-}
-
-.btn-warning {
-  background: linear-gradient(to bottom, #ffc861, var(--warning-color));
-  color: #3b1c00;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-}
-
-.btn-warning:hover {
-  background: linear-gradient(to bottom, #ffd684, var(--warning-hover));
-  transform: translateY(-2px);
-}
-
-.btn-secondary {
-  background: linear-gradient(to bottom, rgba(34, 82, 34, 0.95), rgba(12, 40, 12, 0.95));
-  color: var(--text-primary);
-  border: 1px solid rgba(0, 0, 0, 0.25);
-}
-
-.btn-secondary:hover {
-  background: linear-gradient(to bottom, rgba(42, 102, 42, 0.95), rgba(15, 46, 15, 0.95));
-}
-
-.btn:disabled,
-.btn-disabled {
-  background-color: var(--tertiary-bg);
-  color: var(--text-secondary);
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-/* --- Forms & Inputs --- */
 .input-field {
-  width: 100%;
-  background-color: rgba(6, 32, 6, 0.85);
-  color: var(--text-primary);
-  border: 1px solid rgba(134, 89, 45, 0.6);
-  padding: 0.75rem;
-  border-radius: 0.5rem;
-  font-size: 1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.input-field::placeholder {
-  color: var(--text-secondary);
+  flex: 1 1 160px;
+  min-width: 120px;
+  padding: 4px 6px;
+  border: 2px inset var(--win2k-control-face);
+  background: #ffffff;
+  font-family: inherit;
+  font-size: 11px;
+  color: var(--win2k-text);
 }
 
 .input-field:focus {
   outline: none;
-  border-color: var(--accent-color);
-  box-shadow: 0 0 0 2px rgba(184, 134, 11, 0.4);
+  border: 2px inset var(--win2k-title-gradient-end);
 }
 
-/* --- Lobby List --- */
-#room-list {
+.window-section {
+  padding: 10px;
+  margin-bottom: 12px;
+  background: var(--win2k-button-face);
+}
+
+.window-section h2 {
+  margin: 0 0 8px;
+  font-size: 14px;
+}
+
+.window-section p {
+  margin: 0 0 12px;
+  color: var(--win2k-muted);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 14px;
+  min-height: 24px;
+  min-width: 80px;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 11px;
+  color: var(--win2k-text);
+  background: var(--win2k-button-face);
+  box-shadow:
+    inset -1px -1px var(--win2k-border-dark),
+    inset 1px 1px var(--win2k-border-light),
+    inset -2px -2px var(--win2k-border-mid),
+    inset 2px 2px var(--win2k-border-mid-light);
+}
+
+.btn:active {
+  box-shadow:
+    inset -1px -1px var(--win2k-border-light),
+    inset 1px 1px var(--win2k-border-dark),
+    inset -2px -2px var(--win2k-border-mid-light),
+    inset 2px 2px var(--win2k-border-mid);
+}
+
+.btn:disabled {
+  color: var(--win2k-muted);
+  cursor: default;
+}
+
+.btn-primary {
+  color: #ffffff;
+  background: linear-gradient(90deg, var(--win2k-title-gradient-start), var(--win2k-title-gradient-end));
+}
+
+.btn-warning {
+  color: #000000;
+  background: linear-gradient(90deg, #f9c55a, #d7a23d);
+}
+
+.name-status {
+  margin: 8px 0 0;
+  color: #006400;
+}
+
+.name-status.error {
+  color: #8b0000;
+}
+
+.match-lobby {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+  padding: 10px;
+  margin-bottom: 12px;
+}
+
+.player-card {
+  padding: 10px;
+  background: var(--win2k-button-face);
+}
+
+.player-name {
+  font-weight: bold;
+  margin: 0 0 6px;
+}
+
+.status {
+  margin: 0;
+}
+
+.status.not-ready {
+  color: #8b0000;
+}
+
+.status.ready {
+  color: #006400;
+}
+
+.match-controls {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+#game-info-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px;
+  margin-bottom: 12px;
+  background: var(--win2k-button-face);
+}
+
+#game-info-bar h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.scoreboard {
+  padding: 8px 10px;
+  margin-bottom: 12px;
+  background: var(--win2k-button-face);
+}
+
+#game-container {
+  min-height: 320px;
+  background: #ffffff;
+  padding: 8px;
+}
+
+.lobby-body {
+  height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  text-align: left;
 }
 
-.room-item {
+.lobby-scroll {
+  height: 100%;
+  padding: 6px;
+  overflow-y: auto;
+  background: #ffffff;
+}
+
+.status-body {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  background: linear-gradient(135deg, rgba(26, 78, 26, 0.9), rgba(10, 43, 10, 0.9));
-  padding: 1rem;
-  border-radius: 0.5rem;
-  border: 1px solid rgba(134, 89, 45, 0.6);
-  box-shadow: 0 12px 24px var(--shadow-color);
+  gap: 12px;
 }
 
-.room-item .btn {
-  width: auto;
-  font-size: 1rem;
+.status-indicator {
+  padding: 2px 8px;
+  background: #008000;
+  color: #ffffff;
+  font-weight: bold;
+  border: 2px inset var(--win2k-control-face);
 }
 
-/* --- Modal Styling --- */
+.status-indicator.online {
+  background: #008000;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.7);
+  background: rgba(0, 0, 0, 0.4);
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
-  padding: 1rem;
+  z-index: 999;
 }
 
 .modal-content {
-  background: linear-gradient(135deg, rgba(30, 96, 30, 0.95), rgba(11, 53, 11, 0.95));
-  padding: 2rem;
-  border-radius: 0.75rem;
-  width: 90%;
-  max-width: 32rem; /* 512px */
-  box-shadow: 0 24px 40px var(--shadow-color);
-  border: 1px solid rgba(134, 89, 45, 0.8);
-  text-align: left;
-}
-
-.modal-content h1,
-.modal-content h2 {
-  border: none;
-  padding-bottom: 0;
-  margin-bottom: 0.75rem;
-}
-
-.modal-content p {
-  margin-bottom: 1rem;
-}
-
-#game-selection-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-/* --- Match Lobby (Staging Area) --- */
-#match-lobby {
-  text-align: left;
-}
-
-.match-lobby-container {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
-  margin-bottom: 2rem;
-}
-
-.player-card {
-  background: linear-gradient(145deg, rgba(26, 88, 26, 0.95), rgba(10, 40, 10, 0.95));
-  border-radius: 0.5rem;
-  padding: 1.5rem;
-  border: 2px dashed rgba(184, 134, 11, 0.6);
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.35), 0 14px 28px rgba(0, 0, 0, 0.45);
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.player-card.filled {
-  border-style: solid;
-  border-color: rgba(184, 134, 11, 0.85);
-}
-
-.player-card .player-name {
-  color: var(--text-primary);
-  font-weight: 600;
-}
-
-.player-card .status {
-  font-size: 1.25rem;
-  font-weight: 600;
-  text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.6);
-}
-
-.player-card .status.not-ready {
-  color: var(--success-color);
-}
-
-.player-card .status.ready {
-  color: var(--ready-color);
-}
-
-#match-lobby-controls {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-@media (min-width: 640px) {
-  #match-lobby-controls {
-    flex-direction: row;
-    justify-content: center;
-  }
-
-  #match-lobby-controls .btn {
-    width: auto;
-    min-width: 10rem;
-  }
-}
-
-/* --- Game UI --- */
-#game-ui {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.5rem;
-}
-
-#game-info-bar {
-  width: 100%;
-  max-width: 640px; /* Match game width */
-  background: linear-gradient(135deg, rgba(30, 96, 30, 0.95), rgba(9, 43, 9, 0.95));
-  padding: 0.75rem 1.5rem;
-  border-radius: 0.5rem 0.5rem 0 0;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  box-shadow: 0 14px 26px var(--shadow-color);
-  border: 1px solid rgba(134, 89, 45, 0.6);
-}
-
-#game-info-bar p {
-  margin-bottom: 0.5rem;
-  color: var(--text-primary);
-}
-
-#game-info-bar h2 {
-  margin: 0;
-  border: none;
+  background: var(--win2k-control-face);
   padding: 0;
-  color: var(--accent-color);
-  text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.85);
+  width: min(420px, 90%);
 }
 
-#scoreboard {
-  background: linear-gradient(135deg, rgba(33, 102, 33, 0.95), rgba(8, 35, 8, 0.95));
-  padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
-  max-width: 640px;
-  width: 100%;
-  margin: 0 auto 1rem auto;
-  box-shadow: 0 12px 22px var(--shadow-color);
-  border: 1px solid rgba(134, 89, 45, 0.55);
+.modal-body {
+  padding: 12px;
 }
 
-#scoreboard p {
-  margin: 0;
-  font-weight: 600;
-  color: var(--accent-color);
-  text-align: center;
-  text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.75);
+.modal-body p {
+  margin-top: 0;
+  margin-bottom: 12px;
+  color: var(--win2k-muted);
 }
 
-#game-container {
-  width: 100%;
-  max-width: 640px;
-  background: radial-gradient(circle at center, rgba(23, 82, 23, 0.95), rgba(5, 26, 5, 0.95));
-  border: 1px solid rgba(134, 89, 45, 0.6);
-  box-shadow: 0 24px 40px var(--shadow-color);
-  border-radius: 0 0 0.5rem 0.5rem;
-  overflow: hidden;
-  min-height: 400px;
+.selection-list {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
 }
 
-#turn-indicator {
-  color: var(--text-primary);
-  text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.85);
-  letter-spacing: 0.05em;
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
 }
 
-#game-over-message .modal-content {
-  text-align: center;
+.notification {
+  position: fixed;
+  top: 60px;
+  right: 20px;
+  background: var(--win2k-control-face);
+  border: 2px outset var(--win2k-control-face);
+  padding: 8px 12px;
+  z-index: 1001;
 }
 
-#game-over-message h1 {
-  font-size: 2.25rem;
-  margin-bottom: 1.5rem;
-}
-
-/* --- Responsive Layout Adjustments --- */
-@media (max-width: 640px) {
-  body {
-    padding: 0.5rem;
-  }
-
-  .container {
-    padding: 1.5rem;
-  }
-
-  h1 {
-    font-size: 2.25rem;
-  }
-
-  h2 {
-    font-size: 1.5rem;
-  }
-
-  .match-lobby-container {
+@media (max-width: 960px) {
+  .app-container {
     grid-template-columns: 1fr;
+    grid-template-rows: auto auto 1fr auto;
+  }
+
+  .lobby-list {
+    order: 3;
+  }
+
+  .left-panels {
+    order: 2;
+  }
+
+  .profile-corner {
+    position: static;
+    margin: 8px auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .match-lobby {
+    grid-template-columns: 1fr;
+  }
+
+  .name-row,
+  .name-input-row,
+  .input-row,
+  .match-controls {
+    flex-direction: column;
+  }
+
+  .btn {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the lobby markup to use Windows 2000 inspired window chrome with dedicated sections for setup, lobby, and gameplay
- apply a comprehensive retro Windows 2000 theme with authentic colors, 3D borders, grid layout, and responsive tweaks
- add a placeholder text file that marks where the default avatar image should be dropped for the profile corner UI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7d5359f8883308e4a08f5e390f1bd