### PR TITLE
Harden authentication and session security

### DIFF
--- a/game-server/.gitignore
+++ b/game-server/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+data/sessions.json

--- a/game-server/public/login.html
+++ b/game-server/public/login.html
@@ -21,11 +21,24 @@
             <label for="login-password" class="input-label">Password</label>
             <input id="login-password" name="password" class="input-field" type="password" autocomplete="current-password" required minlength="6">
 
+            <input type="hidden" name="_csrf" id="csrf-token-field">
+
             <div class="auth-actions">
                 <button type="submit" class="btn btn-primary">Login</button>
                 <a href="/signup" class="btn" role="button">Create Account</a>
             </div>
         </form>
     </main>
+    <script>
+        (function populateCsrfField() {
+            const field = document.getElementById('csrf-token-field');
+            if (!field) return;
+            const cookieName = 'homegame.csrf=';
+            const match = document.cookie.split(';').map(part => part.trim()).find(part => part.startsWith(cookieName));
+            if (match) {
+                field.value = decodeURIComponent(match.substring(cookieName.length));
+            }
+        })();
+    </script>
 </body>
 </html>

--- a/game-server/public/signup.html
+++ b/game-server/public/signup.html
@@ -25,11 +25,24 @@
             <label for="signup-password" class="input-label">Password</label>
             <input id="signup-password" name="password" class="input-field" type="password" autocomplete="new-password" required minlength="6">
 
+            <input type="hidden" name="_csrf" id="csrf-token-field">
+
             <div class="auth-actions">
                 <button type="submit" class="btn btn-primary">Sign Up</button>
                 <a href="/login" class="btn" role="button">Back to Login</a>
             </div>
         </form>
     </main>
+    <script>
+        (function populateCsrfField() {
+            const field = document.getElementById('csrf-token-field');
+            if (!field) return;
+            const cookieName = 'homegame.csrf=';
+            const match = document.cookie.split(';').map(part => part.trim()).find(part => part.startsWith(cookieName));
+            if (match) {
+                field.value = decodeURIComponent(match.substring(cookieName.length));
+            }
+        })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace SHA-256 password hashing with scrypt-based hashes and migrate legacy credentials while persisting sessions on disk with a bounded store
- enforce CSRF protections by issuing verification cookies/tokens server-side and validating them across all mutating endpoints
- update the front end and auth forms to submit CSRF tokens and ignore runtime session artifacts in version control

## Testing
- node server.js (started and stopped manually)

------
https://chatgpt.com/codex/tasks/task_e_68d8ba5a3320833099057a8464ac61a6