### PR TITLE
Improve profile UI responsiveness and layering

### DIFF
--- a/game-server/public/style.css
+++ b/game-server/public/style.css
@@ -44,8 +44,8 @@ a {
 
 .app-container {
   display: grid;
-  grid-template-columns: 1.7fr 1.3fr;
-  grid-template-rows: auto 1fr;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto auto 1fr auto;
   gap: 4px;
   padding: 12px;
   min-height: auto;
@@ -59,16 +59,16 @@ a {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  overflow-y: auto;
-  max-height: calc(100vh - 190px);
-  padding-right: 4px;
+  overflow: visible;
+  max-height: none;
+  padding-right: 0;
 }
 
 .lobby-list {
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 190px);
-  overflow-y: auto;
+  max-height: none;
+  overflow: visible;
 }
 
 .footer {
@@ -155,17 +155,17 @@ a {
 }
 
 .profile-corner {
-  position: fixed;
-  top: 72px;
-  right: 16px;
+  position: relative;
+  margin: 12px auto 8px;
+  width: min(100%, 320px);
   background: var(--win2k-control-face);
   padding: 8px 12px;
   display: flex;
   align-items: center;
   gap: 10px;
-  z-index: 1000;
+  z-index: 900;
   border: 2px outset var(--win2k-control-face);
-  min-width: 220px;
+  min-width: 0;
 }
 
 .profile-avatar {
@@ -195,7 +195,7 @@ a {
   background: var(--win2k-control-face);
   border: 2px outset var(--win2k-control-face);
   flex-direction: column;
-  z-index: 1001;
+  z-index: 910;
 }
 
 .profile-corner:hover .profile-dropdown {
@@ -441,7 +441,7 @@ a {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 999;
+  z-index: 1400;
 }
 
 .modal-content {
@@ -598,26 +598,32 @@ a {
   height: 1px;
 }
 
-@media (max-width: 960px) {
+@media (min-width: 961px) {
   .app-container {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto 1fr auto;
-  }
-
-  .lobby-list {
-    order: 3;
-    max-height: none;
+    grid-template-columns: minmax(0, 1.7fr) minmax(0, 1.3fr);
+    grid-template-rows: auto 1fr;
   }
 
   .left-panels {
-    order: 2;
-    max-height: none;
-    overflow: visible;
+    order: initial;
+    overflow-y: auto;
+    max-height: calc(100vh - 190px);
+    padding-right: 4px;
+  }
+
+  .lobby-list {
+    order: initial;
+    max-height: calc(100vh - 190px);
+    overflow-y: auto;
   }
 
   .profile-corner {
-    position: static;
-    margin: 8px auto;
+    position: fixed;
+    top: 72px;
+    right: 16px;
+    margin: 0;
+    width: auto;
+    min-width: 220px;
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor the main grid to use a mobile-first layout and restore the two-column view on wide screens
- update the profile corner styling for better responsiveness and reduce its z-index below modal overlays
- raise modal overlay stacking to avoid profile dropdown collisions with dialogs

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d8bdea96388330b1ffc2970b04dc3d