### PR TITLE
Fix profile z-index hierarchy and modal backdrop handling

### DIFF
--- a/game-server/public/game.js
+++ b/game-server/public/game.js
@@ -141,6 +141,7 @@ if (storedAvatarPath) {
 }
 initializeServiceWorker();
 bootstrapProfile();
+initializeModalDismissal();
 
 // --- UI State Management ---
 // A simple function to switch between the main UI views.
@@ -192,6 +193,19 @@ function initializeIdentity() {
             }
         });
     }
+}
+
+function initializeModalDismissal() {
+    const overlays = Array.from(document.querySelectorAll('.modal-overlay'));
+    overlays.forEach((overlay) => {
+        const modalContent = overlay.querySelector('.modal-content');
+        modalContent?.addEventListener('click', (event) => event.stopPropagation());
+
+        overlay.addEventListener('click', (event) => {
+            if (event.target !== overlay) return;
+            overlay.classList.add('hidden');
+        });
+    });
 }
 
 function sanitizeName(rawName) {

--- a/game-server/public/style.css
+++ b/game-server/public/style.css
@@ -13,6 +13,11 @@
   --win2k-title-gradient-end: #1084d0;
   --win2k-text: #000000;
   --win2k-muted: #4a4a4a;
+  --z-base: 1;
+  --z-dropdown: 100;
+  --z-modal: 1000;
+  --z-toast: 1100;
+  --z-profile: 1200;
 }
 
 * {
@@ -44,7 +49,7 @@ a {
 
 .app-container {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: 1fr;
   grid-template-rows: auto auto 1fr auto;
   gap: 4px;
   padding: 12px;
@@ -155,15 +160,17 @@ a {
 }
 
 .profile-corner {
-  position: relative;
-  margin: 12px auto 8px;
-  width: min(100%, 320px);
+  position: fixed;
+  top: 72px;
+  right: 16px;
+  margin: 0;
+  width: auto;
   background: var(--win2k-control-face);
   padding: 8px 12px;
   display: flex;
   align-items: center;
   gap: 10px;
-  z-index: 900;
+  z-index: var(--z-profile);
   border: 2px outset var(--win2k-control-face);
   min-width: 0;
 }
@@ -195,7 +202,7 @@ a {
   background: var(--win2k-control-face);
   border: 2px outset var(--win2k-control-face);
   flex-direction: column;
-  z-index: 910;
+  z-index: var(--z-dropdown);
 }
 
 .profile-corner:hover .profile-dropdown {
@@ -441,7 +448,7 @@ a {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1400;
+  z-index: var(--z-modal);
 }
 
 .modal-content {
@@ -550,7 +557,7 @@ a {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  z-index: 1200;
+  z-index: var(--z-toast);
 }
 
 .toast {
@@ -559,6 +566,7 @@ a {
   padding: 8px 12px;
   min-width: 220px;
   box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.25);
+  z-index: var(--z-toast);
 }
 
 .toast-success {
@@ -598,6 +606,30 @@ a {
   height: 1px;
 }
 
+@media (min-width: 768px) {
+  .app-container {
+    grid-template-columns: minmax(0, 1.7fr) minmax(0, 1.3fr);
+  }
+
+  .profile-corner {
+    width: min(100%, 320px);
+  }
+}
+
+@media (max-width: 768px) {
+  .profile-corner {
+    position: static;
+    margin: 8px auto;
+    width: fit-content;
+  }
+
+  .profile-dropdown {
+    position: static;
+    margin-top: 8px;
+    width: 100%;
+  }
+}
+
 @media (min-width: 961px) {
   .app-container {
     grid-template-columns: minmax(0, 1.7fr) minmax(0, 1.3fr);
@@ -618,11 +650,6 @@ a {
   }
 
   .profile-corner {
-    position: fixed;
-    top: 72px;
-    right: 16px;
-    margin: 0;
-    width: auto;
     min-width: 220px;
   }
 }


### PR DESCRIPTION
## Summary
- introduce a global z-index scale and apply it to profile, dropdown, modal, and toast layers
- adjust the profile corner positioning for desktop and mobile layouts and tune the responsive grid
- add modal backdrop click handling to close overlays without affecting modal content

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d8db2b6f248330a8f8db55d03cb146