### PR TITLE
Implement CSRF protection across forms and APIs

### DIFF
--- a/game-server/public/index.html
+++ b/game-server/public/index.html
@@ -21,6 +21,7 @@
         </div>
         <form id="avatar-upload-form" class="hidden" enctype="multipart/form-data">
             <input type="file" id="avatar-upload-input" name="avatar" accept="image/*">
+            <input type="hidden" name="_csrf" id="csrf-token">
         </form>
     </div>
 

--- a/game-server/public/login.html
+++ b/game-server/public/login.html
@@ -21,7 +21,7 @@
             <label for="login-password" class="input-label">Password</label>
             <input id="login-password" name="password" class="input-field" type="password" autocomplete="current-password" required minlength="6">
 
-            <input type="hidden" name="_csrf" id="csrf-token-field">
+            <input type="hidden" name="_csrf" id="csrf-token">
 
             <div class="auth-actions">
                 <button type="submit" class="btn btn-primary">Login</button>
@@ -30,15 +30,24 @@
         </form>
     </main>
     <script>
-        (function populateCsrfField() {
-            const field = document.getElementById('csrf-token-field');
+        document.addEventListener('DOMContentLoaded', async () => {
+            const field = document.getElementById('csrf-token');
             if (!field) return;
-            const cookieName = 'homegame.csrf=';
-            const match = document.cookie.split(';').map(part => part.trim()).find(part => part.startsWith(cookieName));
-            if (match) {
-                field.value = decodeURIComponent(match.substring(cookieName.length));
+            try {
+                const response = await fetch('/api/csrf-token', {
+                    credentials: 'include',
+                    headers: { 'Accept': 'application/json' }
+                });
+                if (!response.ok) {
+                    throw new Error('Failed to obtain CSRF token.');
+                }
+                const data = await response.json();
+                field.value = typeof data?.token === 'string' ? data.token : '';
+            } catch (error) {
+                console.error('Unable to load CSRF token.', error);
+                field.value = '';
             }
-        })();
+        });
     </script>
 </body>
 </html>

--- a/game-server/public/signup.html
+++ b/game-server/public/signup.html
@@ -25,7 +25,7 @@
             <label for="signup-password" class="input-label">Password</label>
             <input id="signup-password" name="password" class="input-field" type="password" autocomplete="new-password" required minlength="6">
 
-            <input type="hidden" name="_csrf" id="csrf-token-field">
+            <input type="hidden" name="_csrf" id="csrf-token">
 
             <div class="auth-actions">
                 <button type="submit" class="btn btn-primary">Sign Up</button>
@@ -34,15 +34,24 @@
         </form>
     </main>
     <script>
-        (function populateCsrfField() {
-            const field = document.getElementById('csrf-token-field');
+        document.addEventListener('DOMContentLoaded', async () => {
+            const field = document.getElementById('csrf-token');
             if (!field) return;
-            const cookieName = 'homegame.csrf=';
-            const match = document.cookie.split(';').map(part => part.trim()).find(part => part.startsWith(cookieName));
-            if (match) {
-                field.value = decodeURIComponent(match.substring(cookieName.length));
+            try {
+                const response = await fetch('/api/csrf-token', {
+                    credentials: 'include',
+                    headers: { 'Accept': 'application/json' }
+                });
+                if (!response.ok) {
+                    throw new Error('Failed to obtain CSRF token.');
+                }
+                const data = await response.json();
+                field.value = typeof data?.token === 'string' ? data.token : '';
+            } catch (error) {
+                console.error('Unable to load CSRF token.', error);
+                field.value = '';
             }
-        })();
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add session-based CSRF token management and validation middleware to protect login, signup, logout, and profile routes
- expose an endpoint for retrieving CSRF tokens while ensuring every visitor receives a session identifier
- update HTML forms and frontend scripts to fetch, store, and attach CSRF tokens to POST and upload requests with automatic refresh on failure

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d8dcfed0448330b40e4cb241212c48