### PR TITLE
Use express-session with persistent file storage

### DIFF
--- a/game-server/package.json
+++ b/game-server/package.json
@@ -7,7 +7,9 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "connect-session-file": "^1.0.0",
     "express": "^4.18.2",
+    "express-session": "^1.17.3",
     "socket.io": "^4.7.2"
   }
 }


### PR DESCRIPTION
## Summary
- replace the homegrown JSON session store with express-session backed by connect-session-file for durable cookies
- refresh authentication, CSRF, and logout flows to rely on express-session helpers and remove manual cookie handling
- add the new session store dependencies to package.json

## Testing
- not run (network dependencies unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68d8e9b4fe1883308730d98acadd928f