### PR TITLE
Modernize authentication with JWT and guest session upgrades

### DIFF
--- a/game-server/docs/auth-migration.md
+++ b/game-server/docs/auth-migration.md
@@ -1,0 +1,48 @@
+# Authentication Modernization Overview
+
+## Summary
+The authentication layer now issues signed JSON Web Tokens (JWT) alongside legacy server sessions. JWTs are delivered via HttpOnly cookies while the CSRF double-submit pattern protects all state-changing requests. Anonymous players receive durable guest sessions that persist progress until an account upgrade occurs. Socket.IO connections are authenticated via the same cookie material to maintain continuity between HTTP and WebSocket flows.
+
+## Migration Strategy
+1. **Phase 1 – Parallel tokens**
+   - Deploy the updated server without invalidating existing `homegame.sid` sessions. The middleware automatically mints JWTs for any active legacy session.
+   - Monitor the `/api/session` response to confirm `authMethod` transitions from `session` to `jwt` as returning users receive the new cookies.
+2. **Phase 2 – Client adoption**
+   - Update front-end API clients to send the `x-csrf-token` header sourced from the new `homegame.csrf` cookie. Existing `_csrf` payloads remain supported for backward compatibility during the rollout.
+   - Adjust Socket.IO clients to handle `connect_error` events so they can prompt a refresh when authentication fails.
+3. **Phase 3 – Session retirement (optional)**
+   - After verifying that all active clients rely on JWTs, gradually shorten the TTL of `homegame.sid` until it can be removed. The FileStore may then be decommissioned in favor of stateless auth plus guest persistence files.
+
+## Security Analysis
+| Area | Previous Implementation | New Implementation | Impact |
+| ---- | ----------------------- | ------------------ | ------ |
+| HTTP auth | Server-side `express-session` cookie | `express-session` + JWT (HttpOnly cookie) | Adds stateless validation for Socket.IO and API clients while maintaining compatibility |
+| CSRF | Pseudo-random token stored server-side per session | Double-submit cookie (`homegame.csrf`) with legacy fallback | Simplifies validation and allows stateless flows without lowering security |
+| Guest handling | Ephemeral in-memory per-socket names | File-backed guest session store with signed cookies | Preserves progress across reconnects and enables secure upgrades |
+| Socket.IO | Unauthenticated handshake | Cookie-based middleware verifying JWT/guest signature | Prevents unauthorized socket access and standardizes error propagation |
+| Data cleanup | Session map only | Scheduled guest-session pruning + logout regeneration | Reduces long-lived anonymous data and protects memory usage |
+
+## Testing Recommendations
+- **Unit/Integration**
+  - Verify `/api/csrf-token` sets both JSON payload tokens and the `homegame.csrf` cookie.
+  - Ensure `/api/session` returns accurate `authMethod`, `guest`, and `guestUpgrade` metadata for guest, legacy, and authenticated scenarios.
+- **Authentication flows**
+  1. Anonymous guest -> play match -> upgrade account -> confirm wins transfer.
+  2. Legacy authenticated user -> hit `/api/session` -> confirm new JWT cookie minted without logout.
+  3. Attempt authenticated POST with mismatched CSRF header and cookie -> expect HTTP 403.
+  4. Socket.IO connection with missing/invalid cookies -> expect `connect_error` on client.
+- **Regression**
+  - Run existing gameplay integration tests to ensure room lifecycle unchanged.
+  - Upload avatar workflow should now rely on `req.user` rather than session fields.
+
+## Production Configuration
+- Set strong secrets:
+  ```bash
+  export SESSION_SECRET="$(openssl rand -hex 32)"
+  export JWT_SECRET="$(openssl rand -hex 32)"
+  export GUEST_SESSION_SECRET="$(openssl rand -hex 32)"
+  ```
+- Enable TLS/HTTPS so secure cookies (`secure: true`) remain accessible.
+- Configure a log monitor for `Socket authentication failed` entries to detect tampering attempts.
+- Persist the `data/guest-sessions.json` file on a reliable volume and ensure appropriate file permissions (`600`).
+

--- a/game-server/lib/authTokens.js
+++ b/game-server/lib/authTokens.js
@@ -1,0 +1,96 @@
+"use strict";
+
+const crypto = require('crypto');
+const { signJwt, verifyJwt } = require('./jwt');
+
+const ACCESS_TOKEN_COOKIE = 'homegame.token';
+const CSRF_TOKEN_COOKIE = 'homegame.csrf';
+const TOKEN_DEFAULT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
+const CSRF_TOKEN_MAX_AGE_MS = 1000 * 60 * 60; // 1 hour
+const JWT_AUDIENCE = 'homegame-client';
+const JWT_ISSUER = 'homegame-server';
+
+function generateCsrfToken() {
+    return crypto.randomBytes(32).toString('hex');
+}
+
+function createAccessToken(payload, secret, options = {}) {
+    const baseClaims = {
+        ...payload,
+        type: 'access',
+    };
+    return signJwt(baseClaims, secret, {
+        expiresIn: options.expiresIn || TOKEN_DEFAULT_EXPIRY_SECONDS,
+        audience: JWT_AUDIENCE,
+        issuer: JWT_ISSUER,
+    });
+}
+
+function verifyAccessToken(token, secret) {
+    try {
+        return verifyJwt(token, secret, {
+            audience: JWT_AUDIENCE,
+            issuer: JWT_ISSUER,
+        });
+    } catch (error) {
+        return null;
+    }
+}
+
+function setAccessTokenCookie(res, token, { secure }) {
+    res.cookie(ACCESS_TOKEN_COOKIE, token, {
+        httpOnly: true,
+        sameSite: 'strict',
+        secure,
+        maxAge: TOKEN_DEFAULT_EXPIRY_SECONDS * 1000,
+        path: '/',
+    });
+}
+
+function setCsrfCookie(res, token, { secure }) {
+    res.cookie(CSRF_TOKEN_COOKIE, token, {
+        httpOnly: false,
+        sameSite: 'strict',
+        secure,
+        maxAge: CSRF_TOKEN_MAX_AGE_MS,
+        path: '/',
+    });
+}
+
+function clearAuthCookies(res, { secure }) {
+    res.clearCookie(ACCESS_TOKEN_COOKIE, {
+        httpOnly: true,
+        sameSite: 'strict',
+        secure,
+        path: '/',
+    });
+    res.clearCookie(CSRF_TOKEN_COOKIE, {
+        httpOnly: false,
+        sameSite: 'strict',
+        secure,
+        path: '/',
+    });
+}
+
+function getAccessTokenFromRequest(req) {
+    return req.cookies?.[ACCESS_TOKEN_COOKIE] || null;
+}
+
+function getCsrfCookie(req) {
+    return req.cookies?.[CSRF_TOKEN_COOKIE] || null;
+}
+
+module.exports = {
+    ACCESS_TOKEN_COOKIE,
+    CSRF_TOKEN_COOKIE,
+    TOKEN_DEFAULT_EXPIRY_SECONDS,
+    CSRF_TOKEN_MAX_AGE_MS,
+    generateCsrfToken,
+    createAccessToken,
+    verifyAccessToken,
+    setAccessTokenCookie,
+    setCsrfCookie,
+    clearAuthCookies,
+    getAccessTokenFromRequest,
+    getCsrfCookie,
+};

--- a/game-server/lib/cookies.js
+++ b/game-server/lib/cookies.js
@@ -1,0 +1,30 @@
+"use strict";
+
+function parseCookies(header) {
+    const cookies = {};
+    if (!header || typeof header !== 'string') {
+        return cookies;
+    }
+    const pairs = header.split(';');
+    for (const pair of pairs) {
+        const index = pair.indexOf('=');
+        if (index === -1) {
+            continue;
+        }
+        const key = pair.slice(0, index).trim();
+        const value = pair.slice(index + 1).trim();
+        if (!key) {
+            continue;
+        }
+        try {
+            cookies[key] = decodeURIComponent(value);
+        } catch (error) {
+            cookies[key] = value;
+        }
+    }
+    return cookies;
+}
+
+module.exports = {
+    parseCookies,
+};

--- a/game-server/lib/guestSessions.js
+++ b/game-server/lib/guestSessions.js
@@ -1,0 +1,239 @@
+"use strict";
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+class GuestSessionManager {
+    constructor(options) {
+        this.filePath = options.filePath;
+        this.secret = options.secret;
+        this.ttl = options.ttl || 1000 * 60 * 60 * 24 * 2; // default 2 days
+        this.cleanupIntervalMs = options.cleanupIntervalMs || 1000 * 60 * 30; // 30 minutes
+        this.sessions = new Map();
+        this._dirty = false;
+
+        fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+        this._loadFromDisk();
+        this._scheduleCleanup();
+    }
+
+    createSession() {
+        const id = crypto.randomUUID();
+        const session = {
+            id,
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            data: {
+                displayName: null,
+                wins: 0,
+                lastRoom: null,
+            },
+        };
+        this.sessions.set(id, session);
+        this._markDirty();
+        return { session, token: this._signSessionId(id) };
+    }
+
+    parseToken(token) {
+        if (typeof token !== 'string') {
+            return null;
+        }
+        const [id, signature] = token.split('.');
+        if (!id || !signature) {
+            return null;
+        }
+        const expected = this._createSignature(id);
+        try {
+            const providedBuffer = Buffer.from(signature, 'hex');
+            const expectedBuffer = Buffer.from(expected, 'hex');
+            if (providedBuffer.length !== expectedBuffer.length) {
+                return null;
+            }
+            if (!crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
+                return null;
+            }
+            return id;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    getSessionByToken(token) {
+        const id = this.parseToken(token);
+        if (!id) {
+            return null;
+        }
+        return this.getSession(id);
+    }
+
+    getSession(id) {
+        if (!id) {
+            return null;
+        }
+        const session = this.sessions.get(id);
+        if (!session) {
+            return null;
+        }
+        session.lastSeen = Date.now();
+        this._markDirty();
+        return session;
+    }
+
+    updateSession(id, updater) {
+        const session = this.sessions.get(id);
+        if (!session) {
+            return null;
+        }
+        const nextData = typeof updater === 'function'
+            ? updater({ ...session.data })
+            : { ...session.data, ...updater };
+        session.data = nextData;
+        session.lastSeen = Date.now();
+        this._markDirty();
+        return session;
+    }
+
+    recordDisplayName(id, displayName) {
+        if (!displayName) return;
+        this.updateSession(id, (data) => ({
+            ...data,
+            displayName,
+        }));
+    }
+
+    recordLastRoom(id, roomSnapshot) {
+        if (!roomSnapshot) return;
+        this.updateSession(id, (data) => ({
+            ...data,
+            lastRoom: {
+                ...roomSnapshot,
+                timestamp: Date.now(),
+            },
+        }));
+    }
+
+    recordWin(id) {
+        this.updateSession(id, (data) => ({
+            ...data,
+            wins: (data.wins || 0) + 1,
+        }));
+    }
+
+    promoteSession(id) {
+        const session = this.sessions.get(id);
+        if (!session) {
+            return null;
+        }
+        this.sessions.delete(id);
+        this._markDirty();
+        return {
+            id: session.id,
+            data: session.data,
+        };
+    }
+
+    cleanupExpired() {
+        const now = Date.now();
+        let removed = false;
+        for (const [id, session] of this.sessions.entries()) {
+            if (now - session.lastSeen > this.ttl) {
+                this.sessions.delete(id);
+                removed = true;
+            }
+        }
+        if (removed) {
+            this._markDirty();
+        }
+    }
+
+    stop() {
+        if (this._cleanupTimer) {
+            clearInterval(this._cleanupTimer);
+        }
+    }
+
+    _scheduleCleanup() {
+        this._cleanupTimer = setInterval(() => {
+            try {
+                this.cleanupExpired();
+                this._flushIfDirty();
+            } catch (error) {
+                console.error('Guest session cleanup failed:', error);
+            }
+        }, this.cleanupIntervalMs);
+        if (this._cleanupTimer.unref) {
+            this._cleanupTimer.unref();
+        }
+    }
+
+    _signSessionId(id) {
+        return `${id}.${this._createSignature(id)}`;
+    }
+
+    _createSignature(id) {
+        return crypto.createHmac('sha256', this.secret).update(id).digest('hex');
+    }
+
+    _loadFromDisk() {
+        try {
+            if (!fs.existsSync(this.filePath)) {
+                return;
+            }
+            const raw = fs.readFileSync(this.filePath, 'utf8');
+            const parsed = JSON.parse(raw);
+            if (!Array.isArray(parsed.sessions)) {
+                return;
+            }
+            for (const entry of parsed.sessions) {
+                if (!entry || !entry.id) continue;
+                this.sessions.set(entry.id, {
+                    id: entry.id,
+                    createdAt: entry.createdAt || Date.now(),
+                    lastSeen: entry.lastSeen || Date.now(),
+                    data: entry.data || {},
+                });
+            }
+        } catch (error) {
+            console.error('Failed to load guest sessions:', error);
+        }
+    }
+
+    _markDirty() {
+        this._dirty = true;
+        this._flushSoon();
+    }
+
+    _flushSoon() {
+        if (this._flushTimer) {
+            return;
+        }
+        this._flushTimer = setTimeout(() => {
+            this._flushIfDirty();
+        }, 200);
+    }
+
+    _flushIfDirty() {
+        if (!this._dirty) {
+            return;
+        }
+        this._dirty = false;
+        clearTimeout(this._flushTimer);
+        this._flushTimer = null;
+        const payload = {
+            sessions: Array.from(this.sessions.values()).map((session) => ({
+                id: session.id,
+                createdAt: session.createdAt,
+                lastSeen: session.lastSeen,
+                data: session.data,
+            })),
+        };
+        try {
+            fs.writeFileSync(this.filePath, JSON.stringify(payload, null, 2));
+        } catch (error) {
+            console.error('Failed to persist guest sessions:', error);
+        }
+    }
+}
+
+module.exports = GuestSessionManager;

--- a/game-server/lib/jwt.js
+++ b/game-server/lib/jwt.js
@@ -1,0 +1,77 @@
+"use strict";
+
+const crypto = require('crypto');
+
+function base64UrlEncode(input) {
+    if (typeof input === 'object') {
+        input = JSON.stringify(input);
+    }
+    return Buffer.from(String(input)).toString('base64url');
+}
+
+function base64UrlDecode(str) {
+    return Buffer.from(str, 'base64url').toString('utf8');
+}
+
+function signJwt(payload, secret, options = {}) {
+    const header = {
+        alg: 'HS256',
+        typ: 'JWT',
+    };
+    const issuedAt = Math.floor(Date.now() / 1000);
+    const expiresIn = options.expiresIn || 0;
+    const body = {
+        iat: issuedAt,
+        ...(expiresIn ? { exp: issuedAt + Number(expiresIn) } : {}),
+        ...(options.notBefore ? { nbf: issuedAt + Number(options.notBefore) } : {}),
+        ...(options.audience ? { aud: options.audience } : {}),
+        ...(options.issuer ? { iss: options.issuer } : {}),
+        ...payload,
+    };
+    const encodedHeader = base64UrlEncode(header);
+    const encodedPayload = base64UrlEncode(body);
+    const signature = createSignature(`${encodedHeader}.${encodedPayload}`, secret);
+    return `${encodedHeader}.${encodedPayload}.${signature}`;
+}
+
+function verifyJwt(token, secret, options = {}) {
+    if (typeof token !== 'string') {
+        throw new Error('Invalid token');
+    }
+    const segments = token.split('.');
+    if (segments.length !== 3) {
+        throw new Error('Invalid token');
+    }
+    const [encodedHeader, encodedPayload, signature] = segments;
+    const expectedSignature = createSignature(`${encodedHeader}.${encodedPayload}`, secret);
+    const provided = Buffer.from(signature, 'base64url');
+    const expected = Buffer.from(expectedSignature, 'base64url');
+    if (provided.length !== expected.length || !crypto.timingSafeEqual(provided, expected)) {
+        throw new Error('Invalid signature');
+    }
+
+    const payload = JSON.parse(base64UrlDecode(encodedPayload));
+    const now = Math.floor(Date.now() / 1000);
+    if (typeof payload.exp === 'number' && now >= payload.exp) {
+        throw new Error('Token expired');
+    }
+    if (typeof payload.nbf === 'number' && now < payload.nbf) {
+        throw new Error('Token not yet valid');
+    }
+    if (options.audience && payload.aud !== options.audience) {
+        throw new Error('Invalid audience');
+    }
+    if (options.issuer && payload.iss !== options.issuer) {
+        throw new Error('Invalid issuer');
+    }
+    return payload;
+}
+
+function createSignature(content, secret) {
+    return crypto.createHmac('sha256', secret).update(content).digest('base64url');
+}
+
+module.exports = {
+    signJwt,
+    verifyJwt,
+};


### PR DESCRIPTION
## Summary
- integrate JWT issuance with the existing session stack and adopt a CSRF double-submit cookie while keeping the legacy token fallback
- persist guest sessions to disk, support seamless upgrades to authenticated users, and track guest progress through the gameplay lifecycle
- secure Socket.IO connections with cookie-based middleware and document the rollout, security changes, and testing strategy in a new migration guide

## Testing
- `node server.js` *(fails: local environment is missing express-session dependencies without npm install access)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f738283c8330ab2ffc92d69529c4