### PR TITLE
Add checkers plugin to modular framework

### DIFF
--- a/game-server/package.json
+++ b/game-server/package.json
@@ -4,7 +4,8 @@
   "description": "A local multiplayer game server with themed UI",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node tests/runAll.js"
   },
   "dependencies": {
     "connect-session-file": "^1.0.0",

--- a/game-server/server.js
+++ b/game-server/server.js
@@ -10,6 +10,7 @@ const crypto = require('crypto');
 const session = require('express-session');
 const createFileStore = require('connect-session-file');
 const { Server } = require('socket.io');
+const { createModularGameServer } = require('./src/server/gameGateway');
 
 const GuestSessionManager = require('./lib/guestSessions');
 const {
@@ -29,6 +30,11 @@ const { parseCookies } = require('./lib/cookies');
 const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
+const modularGameServer = createModularGameServer({
+    io,
+    logger: console,
+    pluginDirectory: path.join(__dirname, 'src/plugins'),
+});
 
 const DATA_DIR = path.join(__dirname, 'data');
 const USER_DATA_FILE = path.join(DATA_DIR, 'users.json');
@@ -244,8 +250,6 @@ app.use((req, res, next) => {
 });
 
 let players = {};
-let rooms = {};
-const MAX_PLAYERS_PER_ROOM = 2;
 
 app.get('/api/csrf-token', (req, res) => {
     const sessionId = req.sessionID;
@@ -628,259 +632,61 @@ io.on('connection', (socket) => {
         }
         syncPlayerInRoom(socket.id);
     });
-
-    socket.on('createGame', ({ gameType = 'Checkers', mode = 'lan', roomCode }) => {
-        const normalizedMode = mode || 'lan';
-        const normalizedGameType = gameType || 'Checkers';
-        const roomId = normalizedMode === 'p2p' && roomCode
-            ? String(roomCode).toUpperCase()
-            : `room_${Math.random().toString(36).substr(2, 5)}`;
-
-        if (normalizedMode === 'p2p' && rooms[roomId]) {
-            return joinRoom(socket, roomId);
-        }
-
-        rooms[roomId] = {
-            roomId,
-            hostId: socket.id,
-            gameType: normalizedGameType,
-            mode: normalizedMode,
-            maxPlayers: MAX_PLAYERS_PER_ROOM,
-            players: {},
-            gameState: null,
-            score: { red: 0, black: 0 },
-            round: 1
-        };
-
-        console.log(`[${normalizedMode.toUpperCase()}] Room created: ${roomId} for ${normalizedGameType}`);
-        joinRoom(socket, roomId);
-    });
-
-    socket.on('joinGame', (roomIdRaw) => {
-        const raw = roomIdRaw ? String(roomIdRaw).trim() : '';
-        if (!raw) {
-            return socket.emit('error', 'Room does not exist.');
-        }
-
-        let roomId = raw;
-        let room = rooms[roomId];
-
-        if (!room) {
-            roomId = raw.toUpperCase();
-            room = rooms[roomId];
-        }
-
-        if (!room) {
-            return socket.emit('error', `Room ${raw.toUpperCase()} does not exist.`);
-        }
-
-        const maxPlayers = room.maxPlayers ?? MAX_PLAYERS_PER_ROOM;
-        if (Object.keys(room.players).length >= maxPlayers) {
-            return socket.emit('error', 'Room is full.');
-        }
-
-        joinRoom(socket, roomId);
-    });
-
-    socket.on('playerReady', () => {
-        const player = players[socket.id];
-        if (!player) return;
-        const roomId = player.inRoom;
-        if (rooms[roomId] && rooms[roomId].players[socket.id]) {
-            const participant = rooms[roomId].players[socket.id];
-            participant.isReady = !participant.isReady;
-            console.log(`Player ${socket.id} in room ${roomId} is now ${participant.isReady ? 'READY' : 'NOT READY'}`);
-            io.to(roomId).emit('roomStateUpdate', rooms[roomId]);
-        }
-    });
-
-    socket.on('leaveGame', () => {
-        handlePlayerDeparture(socket, { notify: true });
-    });
-
-    socket.on('startGame', () => {
-        const player = players[socket.id];
-        const roomId = player?.inRoom;
-        const room = rooms[roomId];
-        if (room && room.hostId === socket.id) {
-            const allReady = Object.values(room.players).every(p => p.isReady);
-            if (allReady && Object.keys(room.players).length === room.maxPlayers) {
-                console.log(`Host starting game in room ${roomId}`);
-                const playerIds = Object.keys(room.players);
-                room.players[playerIds[0]].color = 'red';
-                room.players[playerIds[1]].color = 'black';
-
-                room.score = { red: 0, black: 0 };
-                room.round = 1;
-                room.gameState = initializeCheckersState(room.players, room.round, room.score);
-                io.to(roomId).emit('gameStart', { gameState: room.gameState, players: room.players, mode: room.mode });
-            } else {
-                socket.emit('error', 'Cannot start: Not all players are ready or the room is not full.');
-            }
-        }
-    });
-
-    socket.on('movePiece', (moveData) => {
-        const player = players[socket.id];
-        const roomId = player?.inRoom;
-        const room = rooms[roomId];
-        if (!room || !room.gameState) return;
-
-        const validationResult = validateCheckersMove(room.gameState, moveData.from, moveData.to, socket.id);
-
-        if (validationResult.isValid) {
-            room.gameState = validationResult.newGameState;
-            const winner = checkForWinner(room.gameState);
-            if (winner) {
-                const winnerColor = winner;
-                const { winnerName, isMatchWin } = finalizeRoundWin(room, winnerColor);
-
-                if (isMatchWin) {
-                    const account = getPlayerAccountByColor(room, winnerColor);
-                    if (account) {
-                        incrementUserWins(account);
-                    } else {
-                        const guestId = getPlayerGuestByColor(room, winnerColor);
-                        if (guestId) {
-                            guestSessionManager.recordWin(guestId);
-                        }
-                    }
-                }
-
-                io.to(roomId).emit('gameStateUpdate', room.gameState);
-
-                if (isMatchWin) {
-                    return;
-                }
-
-                io.to(roomId).emit('roundEnd', {
-                    winnerColor,
-                    winnerName,
-                    redScore: room.score.red,
-                    blackScore: room.score.black,
-                    round: room.round
+    modularGameServer.attachSocket(socket, {
+        getPlayer: () => players[socket.id],
+        setPlayerRoom: (roomId) => {
+            if (!players[socket.id]) return;
+            players[socket.id].inRoom = roomId;
+            if (players[socket.id]?.guestId) {
+                guestSessionManager.recordLastRoom(players[socket.id].guestId, {
+                    roomId,
+                    gameType: modularGameServer.roomManager.getRoom(roomId)?.gameId || null,
                 });
-
-                room.round += 1;
-                room.gameState = initializeCheckersState(room.players, room.round, room.score);
-
-                setTimeout(() => {
-                    io.to(roomId).emit('gameStart', { gameState: room.gameState, players: room.players, mode: room.mode });
-                }, 2000);
-            } else {
-                room.gameState.score = { ...room.score };
-                io.to(roomId).emit('gameStateUpdate', room.gameState);
             }
-        } else {
-            socket.emit('illegalMove', validationResult.reason);
-        }
+            syncPlayerInRoom(socket.id);
+        },
+        clearPlayerRoom: () => {
+            if (!players[socket.id]) return;
+            players[socket.id].inRoom = null;
+        },
     });
 
     socket.on('disconnect', () => {
         console.log(`User disconnected: ${socket.id}`);
-        handlePlayerDeparture(socket, { notify: false, disconnect: true });
+        if (players[socket.id]?.guestId) {
+            guestSessionManager.recordLastRoom(players[socket.id].guestId, null);
+        }
         delete players[socket.id];
         io.emit('updateRoomList', getOpenRooms());
     });
 });
 
-function joinRoom(socket, roomId) {
-    const player = players[socket.id];
-    const room = rooms[roomId];
-
-    if (!room) {
-        return socket.emit('error', `Room ${roomId} does not exist.`);
-    }
-
-    const maxPlayers = room.maxPlayers ?? MAX_PLAYERS_PER_ROOM;
-    const currentPlayerCount = Object.keys(room.players).length;
-    if (currentPlayerCount >= maxPlayers && !room.players[socket.id]) {
-        return socket.emit('error', 'Room is full.');
-    }
-
-    player.inRoom = roomId;
-    room.players[socket.id] = {
-        playerId: socket.id,
-        isReady: false,
-        username: players[socket.id]?.username || null,
-        account: players[socket.id]?.account || null,
-        guestId: players[socket.id]?.guestId || null,
-    };
-
-    socket.join(roomId);
-    console.log(`Player ${socket.id} joined room ${roomId}`);
-
-    socket.emit('joinedMatchLobby', { room, yourId: socket.id });
-    io.to(roomId).emit('roomStateUpdate', room);
-    io.emit('updateRoomList', getOpenRooms());
-
-    if (players[socket.id]?.guestId) {
-        guestSessionManager.recordLastRoom(players[socket.id].guestId, {
-            roomId,
-            gameType: room.gameType,
-            mode: room.mode,
-        });
-    }
-}
-
-function handlePlayerDeparture(socket, { notify = false, disconnect = false } = {}) {
-    const player = players[socket.id];
-    if (!player) return;
-    const roomId = player.inRoom;
-    if (!roomId) return;
-    const room = rooms[roomId];
-    if (!room) {
-        player.inRoom = null;
-        return;
-    }
-
-    delete room.players[socket.id];
-    player.inRoom = null;
-    socket.leave(roomId);
-
-    if (Object.keys(room.players).length === 0) {
-        console.log(`Room ${roomId} is empty, deleting.`);
-        delete rooms[roomId];
-    } else {
-        if (room.hostId === socket.id) {
-            room.hostId = Object.keys(room.players)[0];
-            console.log(`Host disconnected. New host is ${room.hostId}`);
-        }
-        io.to(roomId).emit('roomStateUpdate', room);
-        if (notify) {
-            io.to(roomId).emit('playerLeft', 'A player has left the match.');
-        } else if (disconnect) {
-            io.to(roomId).emit('playerLeft', 'The other player has disconnected.');
-        }
-    }
-
-    io.emit('updateRoomList', getOpenRooms());
-}
-
 function syncPlayerInRoom(socketId) {
     const player = players[socketId];
-    if (!player) return;
-    const roomId = player.inRoom;
-    if (!roomId) return;
-    const room = rooms[roomId];
+    if (!player?.inRoom) return;
+    const room = modularGameServer.roomManager.getRoom(player.inRoom);
     if (!room) return;
-    if (room.players[socketId]) {
-        room.players[socketId].username = player.username;
-        room.players[socketId].account = player.account;
-        room.players[socketId].guestId = player.guestId;
-        io.to(roomId).emit('roomStateUpdate', room);
-    }
+    const participant = room.playerManager.getPlayer(socketId);
+    if (!participant) return;
+    participant.displayName = player.username || participant.displayName;
+    participant.metadata = {
+        ...(participant.metadata || {}),
+        account: player.account || null,
+        guestId: player.guestId || null,
+    };
+    modularGameServer.notifyRoomUpdate(room.id);
 }
 
 function getOpenRooms() {
     const openRooms = {};
-    for (const id in rooms) {
-        if (rooms[id].mode === 'lan' && Object.keys(rooms[id].players).length < rooms[id].maxPlayers) {
-            openRooms[id] = {
-                roomId: id,
-                gameType: rooms[id].gameType,
-                playerCount: Object.keys(rooms[id].players).length,
-                maxPlayers: rooms[id].maxPlayers
+    for (const room of modularGameServer.roomManager.rooms.values()) {
+        const playerCount = room.playerManager.players.size;
+        if (room.metadata.mode === 'lan' && playerCount < room.playerManager.maxPlayers) {
+            openRooms[room.id] = {
+                roomId: room.id,
+                gameType: room.gameId,
+                playerCount,
+                maxPlayers: room.playerManager.maxPlayers,
             };
         }
     }
@@ -926,108 +732,6 @@ function sanitizeAccountName(name) {
     const cleaned = name.replace(/[^a-zA-Z0-9_-]/g, '');
     if (!cleaned) return null;
     return cleaned.slice(0, 24);
-}
-
-function getPlayerNameByColor(room, color) {
-    if (!room || !color) return null;
-    const player = Object.values(room.players || {}).find(p => p.color === color);
-    const username = player?.username;
-    if (typeof username === 'string') {
-        const trimmed = username.replace(/\s+/g, ' ').trim();
-        if (trimmed) {
-            return trimmed.slice(0, 24);
-        }
-    }
-    return null;
-}
-
-function getPlayerAccountByColor(room, color) {
-    if (!room || !color) return null;
-    const player = Object.values(room.players || {}).find(p => p.color === color);
-    const account = player?.account;
-    if (typeof account === 'string' && account) {
-        return sanitizeAccountName(account);
-    }
-    return null;
-}
-
-function getPlayerGuestByColor(room, color) {
-    if (!room || !color) return null;
-    const player = Object.values(room.players || {}).find(p => p.color === color);
-    if (player?.guestId) {
-        return player.guestId;
-    }
-    return null;
-}
-
-function finalizeRoundWin(room, winnerColor) {
-    const winnerName = getPlayerNameByColor(room, winnerColor) || winnerColor.toUpperCase();
-    room.score[winnerColor] += 1;
-    room.gameState.score = { ...room.score };
-
-    const matchComplete = room.score[winnerColor] >= 2;
-    if (matchComplete) {
-        room.gameState.gameOver = true;
-        room.gameState.winner = winnerColor;
-        room.gameState.winnerName = winnerName;
-    } else {
-        room.gameState.gameOver = false;
-        room.gameState.winner = null;
-        room.gameState.winnerName = null;
-        room.gameState.roundWinner = winnerColor;
-    }
-
-    return { winnerName, isMatchWin: matchComplete };
-}
-
-function initializeCheckersState(players, round = 1, score = { red: 0, black: 0 }) {
-  let board = [ [0, 2, 0, 2, 0, 2, 0, 2], [2, 0, 2, 0, 2, 0, 2, 0], [0, 2, 0, 2, 0, 2, 0, 2], [0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0], [1, 0, 1, 0, 1, 0, 1, 0], [0, 1, 0, 1, 0, 1, 0, 1], [1, 0, 1, 0, 1, 0, 1, 0] ];
-  const redPlayerId = Object.values(players).find(p => p.color === 'red')?.playerId;
-  const blackPlayerId = Object.values(players).find(p => p.color === 'black')?.playerId;
-  return {
-    board: board,
-    turn: 'red',
-    players: { red: redPlayerId, black: blackPlayerId },
-    gameOver: false,
-    winner: null,
-    winnerName: null,
-    round,
-    score: { ...score }
-  };
-}
-
-function validateCheckersMove(gameState, from, to, playerId) {
-    const { board, turn, players } = gameState;
-    const playerColor = players.red === playerId ? 'red' : 'black';
-    if (turn !== playerColor) return { isValid: false, reason: "It's not your turn." };
-    if (!board[from.y] || !board[from.y][from.x] || !board[to.y] || board[to.y][to.x] !== 0) return { isValid: false, reason: 'Invalid start or end position.' };
-    const piece = board[from.y][from.x]; const isKing = piece === 3 || piece === 4;
-    const opponentPieces = playerColor === 'red' ? [2, 4] : [1, 3];
-    const dx = to.x - from.x; const dy = to.y - from.y;
-    if (!isKing) {
-        if (playerColor === 'red' && dy >= 0) return { isValid: false, reason: 'Regular pieces can only move forward.' };
-        if (playerColor === 'black' && dy <= 0) return { isValid: false, reason: 'Regular pieces can only move forward.' };
-    }
-    const newGameState = JSON.parse(JSON.stringify(gameState));
-    if (Math.abs(dx) === 1 && Math.abs(dy) === 1) { newGameState.board[to.y][to.x] = piece; newGameState.board[from.y][from.x] = 0; }
-    else if (Math.abs(dx) === 2 && Math.abs(dy) === 2) {
-        const jumpedX = from.x + dx/2; const jumpedY = from.y + dy/2;
-        if (!opponentPieces.includes(board[jumpedY][jumpedX])) return { isValid: false, reason: 'Invalid jump.'};
-        newGameState.board[to.y][to.x] = piece; newGameState.board[from.y][from.x] = 0; newGameState.board[jumpedY][jumpedX] = 0;
-    } else { return { isValid: false, reason: 'Invalid move.' }; }
-    if (playerColor === 'red' && to.y === 0) newGameState.board[to.y][to.x] = 3;
-    if (playerColor === 'black' && to.y === 7) newGameState.board[to.y][to.x] = 4;
-    newGameState.turn = playerColor === 'red' ? 'black' : 'red';
-    return { isValid: true, newGameState };
-}
-
-function checkForWinner(gameState) {
-    let redPieces = 0; let blackPieces = 0;
-    for(let r of gameState.board) { for(let c of r) {
-        if (c === 1 || c === 3) redPieces++; if (c === 2 || c === 4) blackPieces++;
-    } }
-    if (redPieces === 0) return 'black'; if (blackPieces === 0) return 'red';
-    return null;
 }
 
 function establishSession(req, res, usernameKey, onSuccess) {

--- a/game-server/src/core/command.js
+++ b/game-server/src/core/command.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const EventEmitter = require('events');
+
+class Command {
+    constructor({ type, payload, playerId }) {
+        if (!type) {
+            throw new Error('Command requires a type.');
+        }
+        this.type = type;
+        this.payload = payload || {};
+        this.playerId = playerId || null;
+    }
+
+    execute(/* context */) {
+        throw new Error('execute() must be implemented.');
+    }
+
+    undo(/* context */) {
+        throw new Error('undo() must be implemented.');
+    }
+}
+
+class CommandBus extends EventEmitter {
+    constructor({ stateManager, ruleEngine, playerManager }) {
+        super();
+        this.stateManager = stateManager;
+        this.ruleEngine = ruleEngine;
+        this.playerManager = playerManager;
+        this.history = [];
+    }
+
+    dispatch(commandDescriptor) {
+        const descriptor = normalizeDescriptor(commandDescriptor);
+        const handler = this.ruleEngine.getStrategy(descriptor.type);
+        if (!handler) {
+            throw new Error(`No command handler for type ${descriptor.type}`);
+        }
+        const context = {
+            state: this.stateManager.snapshot().state,
+            playerManager: this.playerManager,
+            playerId: descriptor.playerId,
+            payload: descriptor.payload,
+        };
+        const outcome = handler.execute(context);
+        if (!outcome || typeof outcome !== 'object') {
+            throw new Error('Command handler must return an outcome object.');
+        }
+        if (outcome.error) {
+            throw new Error(outcome.error);
+        }
+        if (typeof outcome.apply === 'function') {
+            const nextState = outcome.apply(this.stateManager.snapshot().state);
+            this.stateManager.replace(nextState, { command: descriptor });
+        } else if (outcome.state) {
+            this.stateManager.replace(outcome.state, { command: descriptor });
+        }
+        if (typeof outcome.getUndo === 'function') {
+            this.history.push({ descriptor, undo: outcome.getUndo() });
+        } else if (typeof outcome.undo === 'function') {
+            this.history.push({ descriptor, undo: () => outcome.undo(this.stateManager) });
+        }
+        this.emit('commandExecuted', { descriptor, outcome });
+        return outcome;
+    }
+
+    undoLast(playerId) {
+        if (!this.history.length) {
+            return null;
+        }
+        const last = this.history.pop();
+        if (playerId && last.descriptor.playerId !== playerId) {
+            this.history.push(last);
+            throw new Error('Only the issuing player can undo this command.');
+        }
+        const undoResult = last.undo();
+        if (undoResult?.state) {
+            this.stateManager.replace(undoResult.state, { undoOf: last.descriptor });
+        }
+        this.emit('commandUndone', { descriptor: last.descriptor });
+        return undoResult;
+    }
+}
+
+function normalizeDescriptor(descriptor = {}) {
+    const { type, payload, playerId } = descriptor;
+    if (!type) {
+        throw new Error('Command descriptor requires a type.');
+    }
+    return { type, payload: payload || {}, playerId: playerId || null };
+}
+
+module.exports = {
+    Command,
+    CommandBus,
+};

--- a/game-server/src/core/gameBuilder.js
+++ b/game-server/src/core/gameBuilder.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const GameInstance = require('./gameInstance');
+const GameStateManager = require('./gameStateManager');
+const PlayerManager = require('./playerManager');
+const RuleEngine = require('./ruleEngine');
+const { CommandBus } = require('./command');
+
+function buildGameInstance({ id, initialState, minPlayers, maxPlayers, strategies = {}, metadata = {} }) {
+    const playerManager = new PlayerManager({ minPlayers, maxPlayers });
+    const stateManager = new GameStateManager(initialState);
+    const ruleEngine = new RuleEngine(id);
+    for (const [key, strategy] of Object.entries(strategies)) {
+        ruleEngine.registerStrategy(key, strategy);
+    }
+    const commandBus = new CommandBus({ stateManager, ruleEngine, playerManager });
+    return new GameInstance({ id, playerManager, stateManager, ruleEngine, commandBus, metadata });
+}
+
+module.exports = {
+    buildGameInstance,
+};

--- a/game-server/src/core/gameFactory.js
+++ b/game-server/src/core/gameFactory.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const GameInstance = require('./gameInstance');
+
+class GameFactory {
+    constructor({ registry }) {
+        if (!registry) {
+            throw new Error('GameFactory requires a GameRegistry.');
+        }
+        this.registry = registry;
+    }
+
+    create(gameId, options = {}) {
+        const definition = this.registry.get(gameId);
+        if (!definition) {
+            throw new Error(`Unknown game type: ${gameId}`);
+        }
+        const instance = definition.create(options);
+        if (!(instance instanceof GameInstance)) {
+            throw new Error(`Game definition ${gameId} must return a GameInstance.`);
+        }
+        return instance;
+    }
+}
+
+module.exports = GameFactory;

--- a/game-server/src/core/gameInstance.js
+++ b/game-server/src/core/gameInstance.js
@@ -1,0 +1,18 @@
+'use strict';
+
+class GameInstance {
+    constructor({ id, playerManager, stateManager, ruleEngine, commandBus, metadata = {} }) {
+        this.id = id;
+        this.playerManager = playerManager;
+        this.stateManager = stateManager;
+        this.ruleEngine = ruleEngine;
+        this.commandBus = commandBus;
+        this.metadata = metadata;
+    }
+
+    getState() {
+        return this.stateManager.snapshot();
+    }
+}
+
+module.exports = GameInstance;

--- a/game-server/src/core/gameRegistry.js
+++ b/game-server/src/core/gameRegistry.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const EventEmitter = require('events');
+
+class GameRegistry extends EventEmitter {
+    constructor() {
+        super();
+        this._definitions = new Map();
+    }
+
+    register(definition) {
+        const normalized = normalizeDefinition(definition);
+        if (this._definitions.has(normalized.id)) {
+            throw new Error(`Game definition with id "${normalized.id}" already registered.`);
+        }
+        this._definitions.set(normalized.id, normalized);
+        this.emit('registered', normalized);
+        return normalized;
+    }
+
+    update(definition) {
+        const normalized = normalizeDefinition(definition);
+        this._definitions.set(normalized.id, normalized);
+        this.emit('updated', normalized);
+        return normalized;
+    }
+
+    unregister(id) {
+        if (!this._definitions.has(id)) {
+            return false;
+        }
+        const definition = this._definitions.get(id);
+        this._definitions.delete(id);
+        this.emit('unregistered', definition);
+        return true;
+    }
+
+    get(id) {
+        return this._definitions.get(id) || null;
+    }
+
+    list() {
+        return Array.from(this._definitions.values());
+    }
+}
+
+function normalizeDefinition(definition = {}) {
+    if (!definition || typeof definition !== 'object') {
+        throw new TypeError('Game definition must be an object.');
+    }
+    const { id, name, version, minPlayers, maxPlayers, create } = definition;
+    if (!id || typeof id !== 'string') {
+        throw new Error('Game definition requires an id.');
+    }
+    if (typeof create !== 'function') {
+        throw new Error(`Game definition "${id}" must implement a create() factory.`);
+    }
+    return {
+        id,
+        name: name || id,
+        version: version || '1.0.0',
+        minPlayers: Number.isInteger(minPlayers) ? minPlayers : 2,
+        maxPlayers: Number.isInteger(maxPlayers) ? maxPlayers : Math.max(4, minPlayers || 2),
+        create,
+    };
+}
+
+module.exports = GameRegistry;

--- a/game-server/src/core/gameRoom.js
+++ b/game-server/src/core/gameRoom.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const EventEmitter = require('events');
+const GameStateManager = require('./gameStateManager');
+const PlayerManager = require('./playerManager');
+const StateSynchronizer = require('./stateSynchronizer');
+
+class GameRoom extends EventEmitter {
+    constructor({ id, hostId, gameId, metadata = {}, playerLimits }) {
+        super();
+        this.id = id;
+        this.hostId = hostId;
+        this.gameId = gameId;
+        this.metadata = metadata;
+        this.createdAt = Date.now();
+        this.playerManager = new PlayerManager(playerLimits);
+        this.gameInstance = null;
+        this.stateSynchronizer = null;
+        this.stateManager = null;
+    }
+
+    attachGame(gameInstance) {
+        this.gameInstance = gameInstance;
+        this.playerManager = gameInstance.playerManager;
+        this.stateManager = gameInstance.stateManager;
+        this.stateSynchronizer = new StateSynchronizer({ stateManager: this.stateManager, roomId: this.id });
+        this.emit('gameAttached', { roomId: this.id, gameInstance });
+        return this.stateSynchronizer;
+    }
+
+    detachGame() {
+        if (this.stateSynchronizer) {
+            this.stateSynchronizer.dispose();
+        }
+        this.stateSynchronizer = null;
+        this.stateManager = new GameStateManager();
+        this.gameInstance = null;
+        this.emit('gameDetached', { roomId: this.id });
+    }
+
+    toJSON() {
+        return {
+            id: this.id,
+            hostId: this.hostId,
+            gameId: this.gameId,
+            createdAt: this.createdAt,
+            metadata: this.metadata,
+            players: this.playerManager.list(),
+            minPlayers: this.playerManager.minPlayers,
+            maxPlayers: this.playerManager.maxPlayers,
+            isGameActive: Boolean(this.gameInstance),
+        };
+    }
+}
+
+module.exports = GameRoom;

--- a/game-server/src/core/gameRoomManager.js
+++ b/game-server/src/core/gameRoomManager.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const EventEmitter = require('events');
+const GameRoom = require('./gameRoom');
+const { generateRoomId } = require('./utils');
+
+class GameRoomManager extends EventEmitter {
+    constructor({ gameFactory, repository }) {
+        super();
+        this.gameFactory = gameFactory;
+        this.repository = repository;
+        this.rooms = new Map();
+    }
+
+    createRoom({ hostId, gameId, mode = 'lan', preferredRoomId, metadata = {}, playerLimits }) {
+        const roomId = preferredRoomId || generateRoomId(mode);
+        if (this.rooms.has(roomId)) {
+            throw new Error(`Room ${roomId} already exists.`);
+        }
+        const room = new GameRoom({ id: roomId, hostId, gameId, metadata, playerLimits });
+        this.rooms.set(roomId, room);
+        this.emit('roomCreated', room.toJSON());
+        return room;
+    }
+
+    deleteRoom(roomId) {
+        const room = this.rooms.get(roomId);
+        if (!room) return null;
+        room.detachGame();
+        this.rooms.delete(roomId);
+        this.repository?.remove?.(roomId);
+        this.emit('roomRemoved', { roomId });
+        return room;
+    }
+
+    getRoom(roomId) {
+        return this.rooms.get(roomId) || null;
+    }
+
+    listRooms() {
+        return Array.from(this.rooms.values()).map(room => room.toJSON());
+    }
+
+    async joinRoom(roomId, player) {
+        const room = this.getRoom(roomId);
+        if (!room) {
+            throw new Error(`Room ${roomId} not found.`);
+        }
+        const playerState = room.playerManager.addPlayer(player);
+        this.emit('roomUpdated', room.toJSON());
+        return { room, player: playerState };
+    }
+
+    async leaveRoom(roomId, playerId) {
+        const room = this.getRoom(roomId);
+        if (!room) {
+            return null;
+        }
+        const removed = room.playerManager.removePlayer(playerId);
+        if (room.playerManager.players.size === 0) {
+            this.deleteRoom(roomId);
+        } else {
+            this.emit('roomUpdated', room.toJSON());
+        }
+        return removed;
+    }
+
+    toggleReady(roomId, playerId) {
+        const room = this.getRoom(roomId);
+        if (!room) throw new Error('Room not found');
+        const player = room.playerManager.toggleReady(playerId);
+        this.emit('roomUpdated', room.toJSON());
+        return player;
+    }
+
+    setReady(roomId, playerId, ready) {
+        const room = this.getRoom(roomId);
+        if (!room) throw new Error('Room not found');
+        const player = room.playerManager.setReady(playerId, ready);
+        this.emit('roomUpdated', room.toJSON());
+        return player;
+    }
+
+    startGame(roomId) {
+        const room = this.getRoom(roomId);
+        if (!room) throw new Error('Room not found');
+        if (!room.playerManager.isReadyToStart()) {
+            throw new Error('Not all players are ready.');
+        }
+        if (!this.gameFactory) {
+            throw new Error('Game factory not configured.');
+        }
+        const definition = this.gameFactory.registry.get(room.gameId);
+        const gameInstance = this.gameFactory.create(room.gameId, {
+            roomId,
+            players: room.playerManager.list(),
+            metadata: room.metadata,
+            minPlayers: definition.minPlayers,
+            maxPlayers: definition.maxPlayers,
+        });
+        const synchronizer = room.attachGame(gameInstance);
+        synchronizer.on('sync', async (payload) => {
+            await this.repository?.save?.(roomId, payload.state);
+            this.emit('gameState', payload);
+        });
+        this.emit('gameStarted', { roomId, state: gameInstance.getState() });
+        return { room, gameInstance };
+    }
+
+    submitCommand(roomId, commandDescriptor) {
+        const room = this.getRoom(roomId);
+        if (!room?.gameInstance) {
+            throw new Error('Game is not active.');
+        }
+        const outcome = room.gameInstance.commandBus.dispatch(commandDescriptor);
+        this.emit('roomUpdated', room.toJSON());
+        return outcome;
+    }
+
+    undoLast(roomId, playerId) {
+        const room = this.getRoom(roomId);
+        if (!room?.gameInstance) {
+            throw new Error('Game is not active.');
+        }
+        const outcome = room.gameInstance.commandBus.undoLast(playerId);
+        this.emit('roomUpdated', room.toJSON());
+        return outcome;
+    }
+}
+
+module.exports = GameRoomManager;

--- a/game-server/src/core/gameStateManager.js
+++ b/game-server/src/core/gameStateManager.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const EventEmitter = require('events');
+const { deepClone } = require('./utils');
+
+class GameStateManager extends EventEmitter {
+    constructor(initialState = {}) {
+        super();
+        this.version = 0;
+        this.state = deepClone(initialState);
+    }
+
+    snapshot() {
+        return {
+            version: this.version,
+            state: deepClone(this.state),
+        };
+    }
+
+    replace(nextState, context = {}) {
+        const previous = this.snapshot();
+        this.state = deepClone(nextState);
+        this.version += 1;
+        const current = this.snapshot();
+        this.emit('stateChanged', { previous, current, context });
+        return current;
+    }
+
+    update(mutator, context = {}) {
+        const current = deepClone(this.state);
+        const nextState = mutator(current);
+        if (typeof nextState === 'undefined') {
+            throw new Error('State mutator must return the next state object.');
+        }
+        return this.replace(nextState, context);
+    }
+}
+
+module.exports = GameStateManager;

--- a/game-server/src/core/index.js
+++ b/game-server/src/core/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+    GameRegistry: require('./gameRegistry'),
+    PluginManager: require('./pluginManager'),
+    GameFactory: require('./gameFactory'),
+    GameRoomManager: require('./gameRoomManager'),
+    GameStateManager: require('./gameStateManager'),
+    PlayerManager: require('./playerManager'),
+    RuleEngine: require('./ruleEngine'),
+    Command: require('./command').Command,
+    CommandBus: require('./command').CommandBus,
+    GameInstance: require('./gameInstance'),
+    buildGameInstance: require('./gameBuilder').buildGameInstance,
+    StateSynchronizer: require('./stateSynchronizer'),
+    ResourceMonitor: require('./resourceMonitor'),
+    InMemoryGameRepository: require('./repositories/inMemoryGameRepository'),
+};

--- a/game-server/src/core/playerManager.js
+++ b/game-server/src/core/playerManager.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const EventEmitter = require('events');
+
+class PlayerManager extends EventEmitter {
+    constructor({ minPlayers = 2, maxPlayers = 4 } = {}) {
+        super();
+        this.minPlayers = minPlayers;
+        this.maxPlayers = maxPlayers;
+        this.players = new Map();
+    }
+
+    addPlayer(player) {
+        if (!player || !player.id) {
+            throw new Error('Player requires an id.');
+        }
+        if (this.players.has(player.id)) {
+            return this.players.get(player.id);
+        }
+        if (this.players.size >= this.maxPlayers) {
+            throw new Error('Player capacity reached.');
+        }
+        const normalized = {
+            id: player.id,
+            displayName: player.displayName || `Player ${this.players.size + 1}`,
+            isReady: Boolean(player.isReady),
+            metadata: player.metadata || {},
+            joinedAt: Date.now(),
+        };
+        this.players.set(normalized.id, normalized);
+        this.emit('playerJoined', normalized);
+        return normalized;
+    }
+
+    removePlayer(id) {
+        if (!this.players.has(id)) {
+            return null;
+        }
+        const removed = this.players.get(id);
+        this.players.delete(id);
+        this.emit('playerLeft', removed);
+        return removed;
+    }
+
+    setReady(id, isReady) {
+        const player = this.players.get(id);
+        if (!player) return null;
+        player.isReady = Boolean(isReady);
+        this.emit('playerReadyState', { id, isReady: player.isReady });
+        return player;
+    }
+
+    toggleReady(id) {
+        const player = this.players.get(id);
+        if (!player) return null;
+        player.isReady = !player.isReady;
+        this.emit('playerReadyState', { id, isReady: player.isReady });
+        return player;
+    }
+
+    getPlayer(id) {
+        return this.players.get(id) || null;
+    }
+
+    list() {
+        return Array.from(this.players.values());
+    }
+
+    isReadyToStart() {
+        if (this.players.size < this.minPlayers) {
+            return false;
+        }
+        return this.list().every(player => player.isReady);
+    }
+
+    hasPlayer(id) {
+        return this.players.has(id);
+    }
+
+    clear() {
+        this.players.clear();
+    }
+
+    toJSON() {
+        return {
+            minPlayers: this.minPlayers,
+            maxPlayers: this.maxPlayers,
+            players: this.list(),
+        };
+    }
+}
+
+module.exports = PlayerManager;

--- a/game-server/src/core/pluginManager.js
+++ b/game-server/src/core/pluginManager.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const EventEmitter = require('events');
+const fs = require('fs');
+const path = require('path');
+
+class PluginManager extends EventEmitter {
+    constructor({ registry, logger = console } = {}) {
+        super();
+        if (!registry) {
+            throw new Error('PluginManager requires a GameRegistry instance.');
+        }
+        this.registry = registry;
+        this.logger = logger;
+        this.plugins = new Map();
+        this.watchers = new Map();
+    }
+
+    async loadFromDirectory(directory) {
+        const resolved = path.resolve(directory);
+        await fs.promises.mkdir(resolved, { recursive: true });
+        const entries = await fs.promises.readdir(resolved, { withFileTypes: true });
+        for (const entry of entries) {
+            if (entry.isDirectory()) {
+                await this.loadPlugin(path.join(resolved, entry.name));
+            } else if (entry.isFile() && entry.name.endsWith('.js') && entry.name !== 'index.js') {
+                await this.loadPlugin(path.join(resolved, entry.name));
+            }
+        }
+        this._watch(resolved);
+    }
+
+    async loadPlugin(pluginPath) {
+        const resolved = path.resolve(pluginPath);
+        delete require.cache[resolved];
+
+        try {
+            const pluginModule = require(resolved);
+            const plugin = pluginModule.default || pluginModule;
+            if (!plugin || typeof plugin.register !== 'function') {
+                throw new Error(`Plugin at ${resolved} must export a register(registry) function.`);
+            }
+            const definition = plugin.register(this.registry, {
+                logger: this.logger,
+            });
+            if (!definition || !definition.id) {
+                throw new Error(`Plugin at ${resolved} did not register a game definition.`);
+            }
+            this.plugins.set(definition.id, { definition, path: resolved });
+            this.emit('pluginLoaded', definition);
+            this.logger.info?.(`Loaded game plugin: ${definition.id}@${definition.version}`);
+            return definition;
+        } catch (error) {
+            this.logger.error?.(`Failed to load plugin ${resolved}:`, error);
+            throw error;
+        }
+    }
+
+    unload(id) {
+        const existing = this.plugins.get(id);
+        if (!existing) return false;
+        this.registry.unregister(id);
+        delete require.cache[existing.path];
+        this.plugins.delete(id);
+        this.emit('pluginUnloaded', existing.definition);
+        return true;
+    }
+
+    reload(id) {
+        const existing = this.plugins.get(id);
+        if (!existing) {
+            throw new Error(`Cannot reload unknown plugin ${id}`);
+        }
+        this.unload(id);
+        return this.loadPlugin(existing.path);
+    }
+
+    _watch(directory) {
+        if (this.watchers.has(directory)) {
+            return;
+        }
+        try {
+            const watcher = fs.watch(directory, { persistent: false }, async (event, filename) => {
+                if (!filename) return;
+                const filePath = path.join(directory, filename);
+                try {
+                    const existing = Array.from(this.plugins.values()).find(p => p.path === filePath);
+                    if (existing) {
+                        await this.reload(existing.definition.id);
+                    } else if (event === 'rename') {
+                        const stats = await fs.promises.stat(filePath).catch(() => null);
+                        if (stats) {
+                            await this.loadPlugin(filePath);
+                        }
+                    }
+                } catch (error) {
+                    this.logger.error?.('Plugin hot-reload failed:', error);
+                }
+            });
+            this.watchers.set(directory, watcher);
+        } catch (error) {
+            this.logger.warn?.('Plugin directory watching unavailable:', error.message);
+        }
+    }
+
+    close() {
+        for (const watcher of this.watchers.values()) {
+            watcher.close();
+        }
+        this.watchers.clear();
+    }
+}
+
+module.exports = PluginManager;

--- a/game-server/src/core/repositories/inMemoryGameRepository.js
+++ b/game-server/src/core/repositories/inMemoryGameRepository.js
@@ -1,0 +1,22 @@
+'use strict';
+
+class InMemoryGameRepository {
+    constructor() {
+        this.states = new Map();
+    }
+
+    async save(roomId, state) {
+        this.states.set(roomId, state);
+        return state;
+    }
+
+    async get(roomId) {
+        return this.states.get(roomId) || null;
+    }
+
+    async remove(roomId) {
+        this.states.delete(roomId);
+    }
+}
+
+module.exports = InMemoryGameRepository;

--- a/game-server/src/core/resourceMonitor.js
+++ b/game-server/src/core/resourceMonitor.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const EventEmitter = require('events');
+const os = require('os');
+
+class ResourceMonitor extends EventEmitter {
+    constructor({ intervalMs = 5000 } = {}) {
+        super();
+        this.intervalMs = intervalMs;
+        this.timer = null;
+        this.metrics = {
+            rooms: 0,
+            activeGames: 0,
+            players: 0,
+            lastUpdated: Date.now(),
+            system: collectSystemMetrics(),
+        };
+    }
+
+    update({ rooms, activeGames, players }) {
+        if (typeof rooms === 'number') this.metrics.rooms = rooms;
+        if (typeof activeGames === 'number') this.metrics.activeGames = activeGames;
+        if (typeof players === 'number') this.metrics.players = players;
+        this.metrics.lastUpdated = Date.now();
+        this.emit('metrics', this.metrics);
+    }
+
+    start() {
+        if (this.timer) return;
+        this.timer = setInterval(() => {
+            this.metrics.system = collectSystemMetrics();
+            this.emit('metrics', this.metrics);
+        }, this.intervalMs);
+    }
+
+    stop() {
+        if (this.timer) {
+            clearInterval(this.timer);
+            this.timer = null;
+        }
+    }
+
+    getSnapshot() {
+        return { ...this.metrics, system: collectSystemMetrics() };
+    }
+}
+
+function collectSystemMetrics() {
+    const memory = process.memoryUsage();
+    return {
+        rss: memory.rss,
+        heapTotal: memory.heapTotal,
+        heapUsed: memory.heapUsed,
+        external: memory.external,
+        cpuLoad: os.loadavg()[0],
+    };
+}
+
+module.exports = ResourceMonitor;

--- a/game-server/src/core/ruleEngine.js
+++ b/game-server/src/core/ruleEngine.js
@@ -1,0 +1,29 @@
+'use strict';
+
+class RuleEngine {
+    constructor(gameId) {
+        this.gameId = gameId;
+        this.strategies = new Map();
+    }
+
+    registerStrategy(key, strategy) {
+        if (!strategy || typeof strategy.execute !== 'function') {
+            throw new Error(`Strategy for ${key} must implement execute()`);
+        }
+        this.strategies.set(key, strategy);
+    }
+
+    getStrategy(key) {
+        return this.strategies.get(key);
+    }
+
+    execute(key, payload) {
+        const strategy = this.getStrategy(key);
+        if (!strategy) {
+            throw new Error(`No strategy registered for ${key} in ${this.gameId}`);
+        }
+        return strategy.execute(payload);
+    }
+}
+
+module.exports = RuleEngine;

--- a/game-server/src/core/stateSynchronizer.js
+++ b/game-server/src/core/stateSynchronizer.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const EventEmitter = require('events');
+
+class StateSynchronizer extends EventEmitter {
+    constructor({ stateManager, roomId }) {
+        super();
+        this.stateManager = stateManager;
+        this.roomId = roomId;
+        this.listener = ({ current, context }) => {
+            this.emit('sync', {
+                roomId: this.roomId,
+                state: current.state,
+                version: current.version,
+                context,
+            });
+        };
+        this.stateManager.on('stateChanged', this.listener);
+    }
+
+    dispose() {
+        if (this.listener) {
+            this.stateManager.off('stateChanged', this.listener);
+        }
+    }
+}
+
+module.exports = StateSynchronizer;

--- a/game-server/src/core/utils.js
+++ b/game-server/src/core/utils.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const crypto = require('crypto');
+
+function deepClone(value) {
+    if (typeof structuredClone === 'function') {
+        return structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+function generateRoomId(prefix = 'room') {
+    return `${prefix}_${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function now() {
+    return Date.now();
+}
+
+module.exports = {
+    deepClone,
+    generateRoomId,
+    now,
+};

--- a/game-server/src/plugins/capture-the-flag/index.js
+++ b/game-server/src/plugins/capture-the-flag/index.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const { buildGameInstance } = require('../../core');
+
+class CaptureFlagMoveStrategy {
+    execute({ state, payload, playerManager, playerId }) {
+        if (!playerManager.hasPlayer(playerId)) {
+            return { error: 'Unknown player.' };
+        }
+        if (state.isComplete) {
+            return { error: 'Game has ended.' };
+        }
+        const { team, flagCaptured } = payload || {};
+        if (!['red', 'blue'].includes(team)) {
+            return { error: 'Invalid team.' };
+        }
+        const player = playerManager.getPlayer(playerId);
+        return {
+            apply(current) {
+                const next = JSON.parse(JSON.stringify(current));
+                next.events.push({
+                    type: 'captureAttempt',
+                    team,
+                    playerId,
+                    timestamp: Date.now(),
+                });
+                if (flagCaptured) {
+                    next.scores[team] += 1;
+                    if (next.scores[team] >= next.scoreToWin) {
+                        next.isComplete = true;
+                        next.winner = team;
+                    }
+                }
+                next.turnIndex = (next.turnIndex + 1) % playerManager.list().length;
+                next.activePlayerId = playerManager.list()[next.turnIndex].id;
+                return next;
+            },
+            getUndo() {
+                return () => ({ state: JSON.parse(JSON.stringify(state)) });
+            },
+            metadata: { playerDisplayName: player.displayName },
+        };
+    }
+}
+
+module.exports = {
+    register(registry) {
+        return registry.register({
+            id: 'capture-the-flag',
+            name: 'Capture the Flag',
+            minPlayers: 4,
+            maxPlayers: 8,
+            version: '1.0.0',
+            create({ roomId, players = [] }) {
+                const game = buildGameInstance({
+                    id: 'capture-the-flag',
+                    minPlayers: 4,
+                    maxPlayers: 8,
+                    initialState: {
+                        roomId,
+                        scores: { red: 0, blue: 0 },
+                        scoreToWin: 3,
+                        events: [],
+                        isComplete: false,
+                        winner: null,
+                        activePlayerId: players[0]?.id || null,
+                        turnIndex: 0,
+                    },
+                    strategies: {
+                        performTurn: new CaptureFlagMoveStrategy(),
+                    },
+                });
+                players.forEach((participant, index) => {
+                    game.playerManager.addPlayer({
+                        id: participant.id,
+                        displayName: participant.displayName,
+                        metadata: {
+                            team: index % 2 === 0 ? 'red' : 'blue',
+                        },
+                        isReady: true,
+                    });
+                });
+                return game;
+            },
+        });
+    },
+};

--- a/game-server/src/plugins/checkers/index.js
+++ b/game-server/src/plugins/checkers/index.js
@@ -1,0 +1,401 @@
+'use strict';
+
+const { buildGameInstance } = require('../../core');
+
+const BOARD_SIZE = 8;
+const COLORS = ['red', 'black'];
+
+class MovePieceStrategy {
+    execute({ state, playerManager, playerId, payload }) {
+        if (!playerManager.hasPlayer(playerId)) {
+            return { error: 'Player not part of this game.' };
+        }
+        if (state.isComplete) {
+            return { error: 'Game already complete.' };
+        }
+        const order = playerManager.list().map(p => p.id);
+        if (!order.includes(playerId)) {
+            return { error: 'Unknown player turn.' };
+        }
+        const turn = state.turn || order[0];
+        if (playerId !== turn) {
+            return { error: 'Not your turn.' };
+        }
+
+        const color = state.players?.[playerId]?.color;
+        if (!color) {
+            return { error: 'Player color not assigned.' };
+        }
+
+        const mustContinue = state.mustContinue;
+        if (mustContinue && mustContinue.playerId !== playerId) {
+            return { error: 'Other player must complete capture.' };
+        }
+
+        const from = payload?.from;
+        const sequence = Array.isArray(payload?.sequence) && payload.sequence.length
+            ? payload.sequence
+            : (payload?.to ? [payload.to] : []);
+
+        if (!isValidCoordinate(from) || sequence.length === 0 || !sequence.every(isValidCoordinate)) {
+            return { error: 'Invalid move coordinates.' };
+        }
+        if (mustContinue && (from.row !== mustContinue.from.row || from.col !== mustContinue.from.col)) {
+            return { error: 'Must continue capture with the same piece.' };
+        }
+
+        const original = cloneState(state);
+        const board = cloneBoard(state.board);
+        let piece = board[from.row][from.col];
+        if (!piece) {
+            return { error: 'No piece at origin square.' };
+        }
+        if (!belongsToColor(piece, color)) {
+            return { error: 'Cannot move opponent piece.' };
+        }
+
+        board[from.row][from.col] = null;
+        let currentRow = from.row;
+        let currentCol = from.col;
+        let capturedAny = false;
+
+        for (const destination of sequence) {
+            const { row: destRow, col: destCol } = destination;
+            if (board[destRow][destCol]) {
+                return { error: 'Destination square occupied.' };
+            }
+            const rowDiff = destRow - currentRow;
+            const colDiff = destCol - currentCol;
+            if (Math.abs(rowDiff) !== Math.abs(colDiff)) {
+                return { error: 'Move must be diagonal.' };
+            }
+            const step = Math.abs(rowDiff);
+            if (step === 1) {
+                if (mustContinue) {
+                    return { error: 'Must continue capturing.' };
+                }
+                if (capturedAny) {
+                    return { error: 'Cannot make simple move after capture in same command.' };
+                }
+                if (!isKing(piece)) {
+                    const forward = getForwardDirection(color);
+                    if (rowDiff !== forward) {
+                        return { error: 'Non-king pieces must move forward.' };
+                    }
+                }
+            } else if (step === 2) {
+                const jumpedRow = currentRow + rowDiff / 2;
+                const jumpedCol = currentCol + colDiff / 2;
+                const jumpedPiece = board[jumpedRow][jumpedCol];
+                if (!jumpedPiece || !isOpponentPiece(jumpedPiece, color)) {
+                    return { error: 'Jump must capture opponent piece.' };
+                }
+                board[jumpedRow][jumpedCol] = null;
+                capturedAny = true;
+                if (!isKing(piece)) {
+                    const forward = getForwardDirection(color);
+                    if (rowDiff !== forward * 2) {
+                        return { error: 'Non-king pieces must capture forward.' };
+                    }
+                }
+            } else {
+                return { error: 'Move distance invalid.' };
+            }
+            currentRow = destRow;
+            currentCol = destCol;
+        }
+
+        if (!capturedAny && !mustContinue && hasAnyCapture(state.board, color)) {
+            return { error: 'Capture available: must capture.' };
+        }
+
+        const promoted = shouldPromote(piece, color, currentRow);
+        if (promoted) {
+            piece = promote(piece);
+        }
+        board[currentRow][currentCol] = piece;
+
+        const next = cloneState(state);
+        next.board = board;
+        next.lastMove = {
+            playerId,
+            from,
+            path: sequence,
+            captured: capturedAny,
+            promoted,
+        };
+
+        const opponentId = order.find(id => id !== playerId) || null;
+        let nextTurn = opponentId;
+        let nextMustContinue = null;
+
+        if (capturedAny) {
+            const canContinue = canPieceCapture(board, currentRow, currentCol, piece, color);
+            if (canContinue) {
+                nextTurn = playerId;
+                nextMustContinue = { playerId, from: { row: currentRow, col: currentCol } };
+            }
+        }
+
+        next.mustContinue = nextMustContinue;
+        next.turn = nextTurn;
+
+        const opponentColor = getOppositeColor(color);
+        const opponentPieces = countPieces(board, opponentColor);
+        const playerPieces = countPieces(board, color);
+        const opponentHasMoves = opponentPieces > 0 && hasAnyMoves(board, opponentColor);
+        const playerHasMoves = playerPieces > 0 && hasAnyMoves(board, color);
+
+        if (opponentPieces === 0 || !opponentHasMoves) {
+            next.isComplete = true;
+            next.winner = playerId;
+            next.turn = null;
+            next.mustContinue = null;
+        } else if (playerPieces === 0 || !playerHasMoves) {
+            next.isComplete = true;
+            next.winner = opponentId;
+            next.turn = null;
+            next.mustContinue = null;
+        }
+
+        return {
+            apply() {
+                return next;
+            },
+            getUndo() {
+                const previous = cloneState(original);
+                return () => ({ state: previous });
+            },
+        };
+    }
+}
+
+function createInitialBoard() {
+    const board = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(null));
+    for (let row = 0; row < 3; row += 1) {
+        for (let col = 0; col < BOARD_SIZE; col += 1) {
+            if ((row + col) % 2 === 1) {
+                board[row][col] = 'b';
+            }
+        }
+    }
+    for (let row = BOARD_SIZE - 3; row < BOARD_SIZE; row += 1) {
+        for (let col = 0; col < BOARD_SIZE; col += 1) {
+            if ((row + col) % 2 === 1) {
+                board[row][col] = 'r';
+            }
+        }
+    }
+    return board;
+}
+
+function isValidCoordinate(coord) {
+    return coord && Number.isInteger(coord.row) && Number.isInteger(coord.col)
+        && coord.row >= 0 && coord.row < BOARD_SIZE && coord.col >= 0 && coord.col < BOARD_SIZE;
+}
+
+function cloneBoard(board = []) {
+    return board.map(row => row.slice());
+}
+
+function cloneState(state = {}) {
+    return JSON.parse(JSON.stringify(state));
+}
+
+function getForwardDirection(color) {
+    return color === 'red' ? -1 : 1;
+}
+
+function isKing(piece) {
+    return piece === 'R' || piece === 'B';
+}
+
+function belongsToColor(piece, color) {
+    return piece && getPieceColor(piece) === color;
+}
+
+function getPieceColor(piece) {
+    if (!piece) return null;
+    return piece.toLowerCase() === 'r' ? 'red' : 'black';
+}
+
+function isOpponentPiece(piece, color) {
+    const pieceColor = getPieceColor(piece);
+    return pieceColor && pieceColor !== color;
+}
+
+function shouldPromote(piece, color, row) {
+    if (isKing(piece)) return false;
+    return (color === 'red' && row === 0) || (color === 'black' && row === BOARD_SIZE - 1);
+}
+
+function promote(piece) {
+    return piece === 'r' ? 'R' : 'B';
+}
+
+function getOppositeColor(color) {
+    return color === 'red' ? 'black' : 'red';
+}
+
+function countPieces(board, color) {
+    let count = 0;
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+        for (let col = 0; col < BOARD_SIZE; col += 1) {
+            if (belongsToColor(board[row][col], color)) {
+                count += 1;
+            }
+        }
+    }
+    return count;
+}
+
+function canPieceCapture(board, row, col, piece, color) {
+    const directions = getMoveDirections(piece, color);
+    for (const [dRow, dCol] of directions) {
+        const midRow = row + dRow;
+        const midCol = col + dCol;
+        const landingRow = row + dRow * 2;
+        const landingCol = col + dCol * 2;
+        if (!isValidCoordinate({ row: landingRow, col: landingCol })) {
+            continue;
+        }
+        if (board[landingRow][landingCol] !== null) {
+            continue;
+        }
+        if (isValidCoordinate({ row: midRow, col: midCol }) && isOpponentPiece(board[midRow][midCol], color)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function canPieceMove(board, row, col, piece, color) {
+    const directions = getMoveDirections(piece, color);
+    for (const [dRow, dCol] of directions) {
+        const nextRow = row + dRow;
+        const nextCol = col + dCol;
+        if (isValidCoordinate({ row: nextRow, col: nextCol }) && board[nextRow][nextCol] === null) {
+            return true;
+        }
+        const landingRow = row + dRow * 2;
+        const landingCol = col + dCol * 2;
+        if (!isValidCoordinate({ row: landingRow, col: landingCol })) {
+            continue;
+        }
+        if (board[landingRow][landingCol] !== null) {
+            continue;
+        }
+        const midRow = row + dRow;
+        const midCol = col + dCol;
+        if (isValidCoordinate({ row: midRow, col: midCol }) && isOpponentPiece(board[midRow][midCol], color)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function hasAnyCapture(board, color) {
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+        for (let col = 0; col < BOARD_SIZE; col += 1) {
+            const piece = board[row][col];
+            if (belongsToColor(piece, color) && canPieceCapture(board, row, col, piece, color)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function hasAnyMoves(board, color) {
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+        for (let col = 0; col < BOARD_SIZE; col += 1) {
+            const piece = board[row][col];
+            if (belongsToColor(piece, color) && canPieceMove(board, row, col, piece, color)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function getMoveDirections(piece, color) {
+    if (isKing(piece)) {
+        return [[1, 1], [1, -1], [-1, 1], [-1, -1]];
+    }
+    const forward = getForwardDirection(color);
+    return [[forward, 1], [forward, -1]];
+}
+
+function registerPlayers(game, players = []) {
+    players.forEach((participant, index) => {
+        const color = COLORS[index % COLORS.length];
+        const added = game.playerManager.addPlayer({
+            id: participant.id,
+            displayName: participant.displayName,
+            isReady: participant.isReady !== false,
+            metadata: { color },
+        });
+        game.stateManager.update((current) => {
+            const next = cloneState(current);
+            next.players = next.players || {};
+            next.players[added.id] = {
+                color,
+                displayName: added.displayName,
+            };
+            next.playerOrder = next.playerOrder || [];
+            if (!next.playerOrder.includes(added.id)) {
+                next.playerOrder.push(added.id);
+            }
+            if (!next.turn) {
+                next.turn = next.playerOrder[0];
+            }
+            return next;
+        });
+    });
+}
+
+module.exports = {
+    register(registry) {
+        return registry.register({
+            id: 'checkers',
+            name: 'Checkers',
+            minPlayers: 2,
+            maxPlayers: 2,
+            version: '1.0.0',
+            create({ roomId, players }) {
+                const initialPlayers = Array.isArray(players) ? players : [];
+                const initialOrder = initialPlayers.map(p => p.id);
+                const game = buildGameInstance({
+                    id: 'checkers',
+                    minPlayers: 2,
+                    maxPlayers: 2,
+                    initialState: {
+                        roomId,
+                        board: createInitialBoard(),
+                        turn: initialOrder[0] || null,
+                        isComplete: false,
+                        winner: null,
+                        mustContinue: null,
+                        players: initialPlayers.reduce((acc, player, index) => {
+                            const color = COLORS[index % COLORS.length];
+                            acc[player.id] = {
+                                color,
+                                displayName: player.displayName,
+                            };
+                            return acc;
+                        }, {}),
+                        playerOrder: initialOrder,
+                        lastMove: null,
+                    },
+                    strategies: {
+                        movePiece: new MovePieceStrategy(),
+                    },
+                });
+                if (initialPlayers.length) {
+                    registerPlayers(game, initialPlayers);
+                }
+                return game;
+            },
+        });
+    },
+};

--- a/game-server/src/plugins/index.js
+++ b/game-server/src/plugins/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const path = require('path');
+
+function getPluginDirectory() {
+    return path.join(__dirname);
+}
+
+module.exports = {
+    getPluginDirectory,
+};

--- a/game-server/src/plugins/tictactoe/index.js
+++ b/game-server/src/plugins/tictactoe/index.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const { buildGameInstance } = require('../../core');
+
+class PlaceMarkStrategy {
+    execute({ state, playerManager, playerId, payload }) {
+        if (!playerManager.hasPlayer(playerId)) {
+            return { error: 'Player not part of this game.' };
+        }
+        const playerOrder = playerManager.list().map(p => p.id);
+        const turn = state.turn || playerOrder[0];
+        if (playerId !== turn) {
+            return { error: 'Not your turn.' };
+        }
+        const { row, col } = payload || {};
+        if (![0, 1, 2].includes(row) || ![0, 1, 2].includes(col)) {
+            return { error: 'Invalid move position.' };
+        }
+        if (state.board[row][col] !== null) {
+            return { error: 'Cell already occupied.' };
+        }
+        const symbolIndex = playerOrder.indexOf(playerId);
+        const symbol = symbolIndex === 0 ? 'X' : 'O';
+        return {
+            apply(current) {
+                const next = JSON.parse(JSON.stringify(current));
+                next.board[row][col] = symbol;
+                next.turn = playerOrder[(symbolIndex + 1) % playerOrder.length];
+                const winner = checkWinner(next.board);
+                if (winner) {
+                    next.winner = playerId;
+                    next.isComplete = true;
+                } else if (next.board.flat().every(cell => cell !== null)) {
+                    next.isComplete = true;
+                }
+                return next;
+            },
+            getUndo() {
+                return () => {
+                    const reverted = JSON.parse(JSON.stringify(state));
+                    return { state: reverted };
+                };
+            },
+        };
+    }
+}
+
+function checkWinner(board) {
+    const lines = [
+        [board[0][0], board[0][1], board[0][2]],
+        [board[1][0], board[1][1], board[1][2]],
+        [board[2][0], board[2][1], board[2][2]],
+        [board[0][0], board[1][0], board[2][0]],
+        [board[0][1], board[1][1], board[2][1]],
+        [board[0][2], board[1][2], board[2][2]],
+        [board[0][0], board[1][1], board[2][2]],
+        [board[0][2], board[1][1], board[2][0]],
+    ];
+    return lines.some(line => line[0] && line.every(cell => cell === line[0]));
+}
+
+module.exports = {
+    register(registry) {
+        const definition = registry.register({
+            id: 'tictactoe',
+            name: 'Tic Tac Toe',
+            minPlayers: 2,
+            maxPlayers: 2,
+            version: '1.0.0',
+            create({ roomId, players }) {
+                const game = buildGameInstance({
+                    id: 'tictactoe',
+                    minPlayers: 2,
+                    maxPlayers: 2,
+                    initialState: {
+                        roomId,
+                        board: [
+                            [null, null, null],
+                            [null, null, null],
+                            [null, null, null],
+                        ],
+                        turn: players?.[0]?.id || null,
+                        isComplete: false,
+                        winner: null,
+                    },
+                    strategies: {
+                        placeMark: new PlaceMarkStrategy(),
+                    },
+                });
+                if (Array.isArray(players)) {
+                    for (const participant of players) {
+                        game.playerManager.addPlayer({
+                            id: participant.id,
+                            displayName: participant.displayName,
+                            isReady: true,
+                        });
+                    }
+                }
+                return game;
+            },
+        });
+        return definition;
+    },
+};

--- a/game-server/src/server/gameGateway.js
+++ b/game-server/src/server/gameGateway.js
@@ -1,0 +1,280 @@
+'use strict';
+
+const EventEmitter = require('events');
+const {
+    GameRegistry,
+    PluginManager,
+    GameFactory,
+    GameRoomManager,
+    ResourceMonitor,
+    InMemoryGameRepository,
+} = require('../core');
+const { getPluginDirectory } = require('../plugins');
+
+class ModularGameServer extends EventEmitter {
+    constructor({ io, logger = console, pluginDirectory }) {
+        super();
+        this.io = io;
+        this.logger = logger;
+        this.registry = new GameRegistry();
+        this.pluginManager = new PluginManager({ registry: this.registry, logger });
+        this.factory = new GameFactory({ registry: this.registry });
+        this.repository = new InMemoryGameRepository();
+        this.roomManager = new GameRoomManager({ gameFactory: this.factory, repository: this.repository });
+        this.resourceMonitor = new ResourceMonitor({ intervalMs: 3000 });
+        this.resourceMonitor.start();
+        this._init(pluginDirectory);
+        this._wireRoomEvents();
+        this._wirePluginEvents();
+    }
+
+    async _init(pluginDirectory) {
+        const directory = pluginDirectory || getPluginDirectory();
+        try {
+            await this.pluginManager.loadFromDirectory(directory);
+            this.io.emit('availableGames', this.registry.list().map(({ id, name, minPlayers, maxPlayers }) => ({ id, name, minPlayers, maxPlayers })));
+        } catch (error) {
+            this.logger.error('Failed to load game plugins:', error);
+        }
+    }
+
+    _wireRoomEvents() {
+        const updateMetrics = () => {
+            this.resourceMonitor.update({
+                rooms: this.roomManager.rooms.size,
+                activeGames: Array.from(this.roomManager.rooms.values()).filter(room => room.gameInstance).length,
+                players: Array.from(this.roomManager.rooms.values()).reduce((sum, room) => sum + room.playerManager.players.size, 0),
+            });
+            this.io.emit('serverMetrics', this.resourceMonitor.getSnapshot());
+        };
+
+        const emitRooms = () => {
+            this.io.emit('updateRoomList', this._serializeRooms());
+            updateMetrics();
+        };
+
+        this.roomManager.on('roomCreated', () => emitRooms());
+        this.roomManager.on('roomUpdated', ({ id }) => {
+            const room = this.roomManager.getRoom(id);
+            if (room) {
+                this.io.to(id).emit('roomStateUpdate', room.toJSON());
+            }
+            emitRooms();
+        });
+        this.roomManager.on('roomRemoved', ({ roomId }) => {
+            this.io.to(roomId).emit('roomClosed');
+            emitRooms();
+        });
+        this.roomManager.on('gameStarted', ({ roomId, state }) => {
+            const room = this.roomManager.getRoom(roomId);
+            if (room) {
+                this.io.to(roomId).emit('gameStart', {
+                    gameState: state.state,
+                    players: room.playerManager.list(),
+                    gameId: room.gameId,
+                });
+            }
+            updateMetrics();
+        });
+        this.roomManager.on('gameState', ({ roomId, state, version, context }) => {
+            this.io.to(roomId).emit('gameStateUpdate', {
+                state,
+                version,
+                context,
+            });
+        });
+    }
+
+    attachSocket(socket, { getPlayer, setPlayerRoom, clearPlayerRoom }) {
+        socket.emit('availableGames', this.registry.list().map(({ id, name, minPlayers, maxPlayers }) => ({ id, name, minPlayers, maxPlayers })));
+        socket.emit('updateRoomList', this._serializeRooms());
+        socket.on('createGame', (payload = {}) => {
+            try {
+                const { gameType, mode = 'lan', roomCode, minPlayers, maxPlayers } = payload;
+                const definition = this._resolveGameDefinition(gameType);
+                const player = getPlayer();
+                const room = this.roomManager.createRoom({
+                    hostId: socket.id,
+                    gameId: definition.id,
+                    mode,
+                    preferredRoomId: mode === 'p2p' && roomCode ? String(roomCode).toUpperCase() : undefined,
+                    playerLimits: {
+                        minPlayers: minPlayers || definition.minPlayers,
+                        maxPlayers: maxPlayers || definition.maxPlayers,
+                    },
+                    metadata: { mode },
+                });
+                this.roomManager.joinRoom(room.id, {
+                    id: socket.id,
+                    displayName: player?.username || player?.displayName || 'Player',
+                    metadata: { account: player?.account || null },
+                    isReady: true,
+                });
+                setPlayerRoom(room.id);
+                socket.join(room.id);
+                this.io.to(room.id).emit('roomStateUpdate', room.toJSON());
+            } catch (error) {
+                this.logger.error('Failed to create game:', error);
+                socket.emit('error', error.message);
+            }
+        });
+
+        socket.on('joinGame', async (roomIdRaw) => {
+            try {
+                const roomId = String(roomIdRaw || '').trim();
+                if (!roomId) throw new Error('Room does not exist.');
+                const room = this.roomManager.getRoom(roomId) || this.roomManager.getRoom(roomId.toUpperCase());
+                if (!room) {
+                    throw new Error(`Room ${roomId.toUpperCase()} does not exist.`);
+                }
+                if (room.playerManager.players.size >= room.playerManager.maxPlayers) {
+                    throw new Error('Room is full.');
+                }
+                const player = getPlayer();
+                await this.roomManager.joinRoom(room.id, {
+                    id: socket.id,
+                    displayName: player?.username || player?.displayName || 'Player',
+                    metadata: { account: player?.account || null },
+                    isReady: false,
+                });
+                setPlayerRoom(room.id);
+                socket.join(room.id);
+                this.io.to(room.id).emit('roomStateUpdate', room.toJSON());
+            } catch (error) {
+                socket.emit('error', error.message);
+            }
+        });
+
+        socket.on('playerReady', () => {
+            const player = getPlayer();
+            if (!player?.inRoom) return;
+            try {
+                const updated = this.roomManager.toggleReady(player.inRoom, socket.id);
+                if (updated) {
+                    this.io.to(player.inRoom).emit('roomStateUpdate', this.roomManager.getRoom(player.inRoom).toJSON());
+                }
+            } catch (error) {
+                socket.emit('error', error.message);
+            }
+        });
+
+        socket.on('startGame', () => {
+            const player = getPlayer();
+            if (!player?.inRoom) return;
+            const room = this.roomManager.getRoom(player.inRoom);
+            if (!room || room.hostId !== socket.id) {
+                socket.emit('error', 'Only the host can start the game.');
+                return;
+            }
+            try {
+                this.roomManager.startGame(player.inRoom);
+            } catch (error) {
+                socket.emit('error', error.message);
+            }
+        });
+
+        socket.on('submitMove', (commandDescriptor = {}) => {
+            const player = getPlayer();
+            if (!player?.inRoom) return;
+            try {
+                this.roomManager.submitCommand(player.inRoom, { ...commandDescriptor, playerId: socket.id });
+            } catch (error) {
+                socket.emit('error', error.message);
+            }
+        });
+
+        socket.on('undoMove', () => {
+            const player = getPlayer();
+            if (!player?.inRoom) return;
+            try {
+                this.roomManager.undoLast(player.inRoom, socket.id);
+            } catch (error) {
+                socket.emit('error', error.message);
+            }
+        });
+
+        socket.on('leaveGame', () => {
+            const player = getPlayer();
+            if (!player?.inRoom) return;
+            this._leaveRoom(socket, player.inRoom, clearPlayerRoom);
+        });
+
+        socket.on('disconnect', () => {
+            const player = getPlayer();
+            if (player?.inRoom) {
+                this._leaveRoom(socket, player.inRoom, clearPlayerRoom, { disconnect: true });
+            }
+        });
+    }
+
+    _leaveRoom(socket, roomId, clearPlayerRoom, { disconnect = false } = {}) {
+        this.roomManager.leaveRoom(roomId, socket.id)
+            .then(() => {
+                socket.leave(roomId);
+                clearPlayerRoom();
+                const room = this.roomManager.getRoom(roomId);
+                if (room) {
+                    this.io.to(roomId).emit('roomStateUpdate', room.toJSON());
+                }
+                if (disconnect) {
+                    this.io.to(roomId).emit('playerLeft', 'A player has disconnected.');
+                }
+            })
+            .catch((error) => {
+                this.logger.error('Failed to leave room:', error);
+            });
+    }
+
+    notifyRoomUpdate(roomId) {
+        const room = this.roomManager.getRoom(roomId);
+        if (!room) {
+            return;
+        }
+        this.io.to(roomId).emit('roomStateUpdate', room.toJSON());
+        this.io.emit('updateRoomList', this._serializeRooms());
+    }
+
+    _wirePluginEvents() {
+        const broadcast = () => {
+            this.io.emit('availableGames', this.registry.list().map(({ id, name, minPlayers, maxPlayers }) => ({ id, name, minPlayers, maxPlayers })));
+        };
+        this.pluginManager.on('pluginLoaded', broadcast);
+        this.pluginManager.on('pluginUnloaded', broadcast);
+        this.registry.on('updated', broadcast);
+    }
+
+    _serializeRooms() {
+        const summary = {};
+        for (const room of this.roomManager.rooms.values()) {
+            if (room.metadata.mode === 'lan' && room.playerManager.players.size < room.playerManager.maxPlayers) {
+                summary[room.id] = {
+                    roomId: room.id,
+                    gameType: room.gameId,
+                    playerCount: room.playerManager.players.size,
+                    maxPlayers: room.playerManager.maxPlayers,
+                };
+            }
+        }
+        return summary;
+    }
+
+    _resolveGameDefinition(gameType) {
+        if (gameType && this.registry.get(gameType)) {
+            return this.registry.get(gameType);
+        }
+        const available = this.registry.list();
+        if (!available.length) {
+            throw new Error('No games are currently available.');
+        }
+        return available[0];
+    }
+}
+
+function createModularGameServer(options) {
+    const server = new ModularGameServer(options);
+    return server;
+}
+
+module.exports = {
+    createModularGameServer,
+};

--- a/game-server/tests/runAll.js
+++ b/game-server/tests/runAll.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const {
+    GameRegistry,
+    PluginManager,
+    GameFactory,
+    GameRoomManager,
+    InMemoryGameRepository,
+    PlayerManager,
+} = require('../src/core');
+
+const tests = [];
+function test(name, fn) {
+    tests.push({ name, fn });
+}
+
+function createLogger() {
+    return {
+        info: () => {},
+        error: () => {},
+        warn: () => {},
+        debug: () => {},
+    };
+}
+
+test('GameRegistry registers and lists games', () => {
+    const registry = new GameRegistry();
+    registry.register({
+        id: 'dummy',
+        minPlayers: 2,
+        maxPlayers: 2,
+        create() { throw new Error('not used'); },
+    });
+    const listed = registry.list();
+    assert.strictEqual(listed.length, 1);
+    assert.strictEqual(listed[0].id, 'dummy');
+});
+
+test('PluginManager loads TicTacToe and Checkers plugins', async () => {
+    const registry = new GameRegistry();
+    const manager = new PluginManager({ registry, logger: createLogger() });
+    await manager.loadFromDirectory(path.join(__dirname, '..', 'src', 'plugins'));
+    const game = registry.get('tictactoe');
+    assert.ok(game, 'tictactoe plugin should register');
+    assert.strictEqual(game.minPlayers, 2);
+    const checkers = registry.get('checkers');
+    assert.ok(checkers, 'checkers plugin should register');
+    assert.strictEqual(checkers.maxPlayers, 2);
+});
+
+test('PlayerManager enforces capacity and readiness', () => {
+    const manager = new PlayerManager({ minPlayers: 2, maxPlayers: 4 });
+    manager.addPlayer({ id: 'p1', displayName: 'One' });
+    manager.addPlayer({ id: 'p2', displayName: 'Two' });
+    assert.strictEqual(manager.isReadyToStart(), false);
+    manager.setReady('p1', true);
+    manager.setReady('p2', true);
+    assert.strictEqual(manager.isReadyToStart(), true);
+    manager.toggleReady('p2');
+    assert.strictEqual(manager.isReadyToStart(), false);
+});
+
+test('GameRoomManager creates rooms and plays TicTacToe', async () => {
+    const registry = new GameRegistry();
+    const logger = createLogger();
+    const pluginManager = new PluginManager({ registry, logger });
+    await pluginManager.loadFromDirectory(path.join(__dirname, '..', 'src', 'plugins'));
+    const factory = new GameFactory({ registry });
+    const repository = new InMemoryGameRepository();
+    const manager = new GameRoomManager({ gameFactory: factory, repository });
+
+    const room = manager.createRoom({ hostId: 'host', gameId: 'tictactoe', metadata: { mode: 'lan' } });
+    await manager.joinRoom(room.id, { id: 'host', displayName: 'Host', isReady: true });
+    await manager.joinRoom(room.id, { id: 'guest', displayName: 'Guest', isReady: true });
+    manager.startGame(room.id);
+    const outcome = manager.submitCommand(room.id, { type: 'placeMark', playerId: 'host', payload: { row: 0, col: 0 } });
+    assert.ok(outcome, 'Command should execute');
+    const state = repository.states.get(room.id);
+    assert.strictEqual(state.board[0][0], 'X');
+});
+
+test('GameRoomManager undo restores previous state', async () => {
+    const registry = new GameRegistry();
+    const logger = createLogger();
+    const pluginManager = new PluginManager({ registry, logger });
+    await pluginManager.loadFromDirectory(path.join(__dirname, '..', 'src', 'plugins'));
+    const factory = new GameFactory({ registry });
+    const repository = new InMemoryGameRepository();
+    const manager = new GameRoomManager({ gameFactory: factory, repository });
+
+    const room = manager.createRoom({ hostId: 'host', gameId: 'tictactoe', metadata: { mode: 'lan' } });
+    await manager.joinRoom(room.id, { id: 'host', displayName: 'Host', isReady: true });
+    await manager.joinRoom(room.id, { id: 'guest', displayName: 'Guest', isReady: true });
+    manager.startGame(room.id);
+    manager.submitCommand(room.id, { type: 'placeMark', playerId: 'host', payload: { row: 0, col: 0 } });
+    manager.undoLast(room.id, 'host');
+    const state = repository.states.get(room.id);
+    assert.strictEqual(state.board[0][0], null, 'Undo should reset cell');
+});
+
+test('GameRoomManager plays Checkers with capture and promotion rules', async () => {
+    const registry = new GameRegistry();
+    const logger = createLogger();
+    const pluginManager = new PluginManager({ registry, logger });
+    await pluginManager.loadFromDirectory(path.join(__dirname, '..', 'src', 'plugins'));
+    const factory = new GameFactory({ registry });
+    const repository = new InMemoryGameRepository();
+    const manager = new GameRoomManager({ gameFactory: factory, repository });
+
+    const room = manager.createRoom({ hostId: 'host', gameId: 'checkers', metadata: { mode: 'classic' } });
+    await manager.joinRoom(room.id, { id: 'host', displayName: 'Host', isReady: true });
+    await manager.joinRoom(room.id, { id: 'guest', displayName: 'Guest', isReady: true });
+    manager.startGame(room.id);
+
+    manager.submitCommand(room.id, { type: 'movePiece', playerId: 'host', payload: { from: { row: 5, col: 0 }, to: { row: 4, col: 1 } } });
+    let state = repository.states.get(room.id);
+    assert.strictEqual(state.board[5][0], null, 'Moved piece should leave origin square empty');
+    assert.strictEqual(state.board[4][1], 'r', 'Red piece should occupy new square');
+
+    manager.submitCommand(room.id, { type: 'movePiece', playerId: 'guest', payload: { from: { row: 2, col: 3 }, to: { row: 3, col: 2 } } });
+    state = repository.states.get(room.id);
+    assert.strictEqual(state.board[3][2], 'b', 'Black piece should move diagonally forward');
+
+    manager.submitCommand(room.id, { type: 'movePiece', playerId: 'host', payload: { from: { row: 4, col: 1 }, to: { row: 2, col: 3 } } });
+    state = repository.states.get(room.id);
+    assert.strictEqual(state.board[3][2], null, 'Captured piece should be removed');
+    assert.strictEqual(state.board[2][3], 'r', 'Capturing piece should land two squares ahead');
+    assert.strictEqual(state.turn, 'guest', 'Turn should pass to opponent after capture');
+    assert.strictEqual(state.players.host.color, 'red');
+    assert.strictEqual(state.players.guest.color, 'black');
+});
+
+(async () => {
+    let failures = 0;
+    for (const { name, fn } of tests) {
+        try {
+            const result = fn();
+            if (result && typeof result.then === 'function') {
+                await result;
+            }
+            console.log(`\u2714\ufe0f  ${name}`);
+        } catch (error) {
+            failures += 1;
+            console.error(`\u274c ${name}:`, error);
+        }
+    }
+    if (failures > 0) {
+        process.exitCode = 1;
+    }
+})();


### PR DESCRIPTION
## Summary
- add a modular Checkers game plugin with move validation, capture chains, promotion, and win detection
- register player colors during room handoff so Checkers rounds retain turn order and metadata
- extend the test suite to cover Checkers plugin loading and multi-step gameplay flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8fe44d28483308a177f4f1dcf1d40