### PR TITLE
Switch to session-file-store and add setup scripts

### DIFF
--- a/game-server/.env.example
+++ b/game-server/.env.example
@@ -1,0 +1,4 @@
+SESSION_SECRET=change_me
+JWT_SECRET=change_me
+GUEST_SESSION_SECRET=change_me
+ALLOWED_ORIGINS=http://localhost:3000

--- a/game-server/.gitignore
+++ b/game-server/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 data/sessions.json
+.sessions/

--- a/game-server/README.md
+++ b/game-server/README.md
@@ -14,24 +14,51 @@ This project is a lightweight, self-hosted web server for playing classic multip
 1.  **Node.js:** Ensure you have Node.js installed on the machine that will act as the server.
 2.  **Clone Repository:** Download or clone this repository to your machine.
 
+## Configuration
+
+1. Copy the example environment file and update the secrets before running the server:
+    ```bash
+    cp .env.example .env
+    ```
+2. Edit `.env` to provide strong, unique values for:
+    - `SESSION_SECRET`
+    - `JWT_SECRET`
+    - `GUEST_SESSION_SECRET`
+    - `ALLOWED_ORIGINS` (comma-separated list of allowed browser origins)
+3. In production deployments behind HTTPS, set `NODE_ENV=production` so secure cookies are enforced.
+
 ## Installation
 
-1.  Open a terminal or command prompt and navigate to the `game-server` root directory.
-2.  Run the following command to install the necessary dependencies:
+1. Open a terminal or command prompt and navigate to the `game-server` root directory.
+2. Install the dependencies:
     ```
-    npm install
+    npm ci
     ```
-3.  **CachyOS users:** run `./install_cachyos.sh` to automatically install Node.js (if needed) and install the project dependencies.
+    - CachyOS users can run `./install_cachyos.sh` to automatically install Node.js (if needed) and run `npm ci`.
 
 ## Running the Server
 
-1.  Once the installation is complete, run the following command to start the server:
-    ```
-    npm start
-    ```
-    - CachyOS users can alternatively run `./run_cachyos.sh` to verify dependencies and launch the server automatically.
-2.  The server will now be running. You can access the game hub by opening a web browser and going to `http://[SERVER-IP-ADDRESS]:8081`. You can find your server's local IP address in your network settings. If you are on the server machine itself, you can use `http://localhost:8081`.
+- **Development:**
+  ```
+  npm run dev
+  ```
+  This starts the server with live-reload via `nodemon` on the default port `8081`.
+- **Production:**
+  ```
+  npm start
+  ```
+  The server will listen on `PORT` (defaults to `8081`). Access it at `http://[SERVER-IP-ADDRESS]:8081` or `http://localhost:8081` when running locally.
+- CachyOS users can run `./run_cachyos.sh` to verify dependencies and launch the server automatically.
 
-## Windows Shortcut
+## Windows & Linux Shortcuts
 
 - Windows users can double-click `run_windows.bat` to check for Node.js, install dependencies, and start the server automatically.
+- For a full environment bootstrap, use the cross-platform setup scripts:
+  - PowerShell: `./setup.ps1`
+  - CachyOS/Linux: `./setup_cachyos.sh`
+
+## Security Notes
+
+- Use strong, unique secrets in your `.env` file.
+- Behind HTTPS, ensure `NODE_ENV=production` so cookies are marked `secure`.
+- Restrict `ALLOWED_ORIGINS` to the domains that should access the server APIs.

--- a/game-server/install_cachyos.sh
+++ b/game-server/install_cachyos.sh
@@ -21,7 +21,6 @@ need_pkg() {
 
 need_pkg nodejs
 need_pkg npm
-need_pkg python
 
 echo "[*] Installing Node deps via npm ci..."
 if [ ! -d node_modules ]; then

--- a/game-server/package-lock.json
+++ b/game-server/package-lock.json
@@ -9,7 +9,14 @@
       "version": "1.0.0",
       "dependencies": {
         "express": "^4.18.2",
+        "express-session": "^1.17.3",
+        "ioredis": "^5.3.2",
+        "session-file-store": "^1.5.0",
+        "sharp": "^0.33.2",
         "socket.io": "^4.7.2"
+      },
+      "devDependencies": {
+        "nodemon": "^3.1.0"
       }
     },
     "node_modules/@socket.io/component-emitter": {

--- a/game-server/package.json
+++ b/game-server/package.json
@@ -5,18 +5,22 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
+    "dev": "nodemon server.js",
     "test": "node tests/runAll.js",
-    "lint": "node scripts/security-lint.js --eslint-only",
+    "lint": "node scripts/security-lint.js",
     "audit": "npm audit --audit-level=high || true",
     "security:scan": "node scripts/security-lint.js --audit-only",
     "benchmark": "node scripts/benchmark.js"
   },
   "dependencies": {
-    "connect-session-file": "^1.0.0",
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "ioredis": "^5.3.2",
+    "session-file-store": "^1.5.0",
     "sharp": "^0.33.2",
     "socket.io": "^4.7.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0"
   }
 }

--- a/game-server/run_windows.bat
+++ b/game-server/run_windows.bat
@@ -3,7 +3,6 @@ setlocal enabledelayedexpansion
 
 where node >nul 2>nul || (echo Node.js not found in PATH & pause & exit /b 1)
 where npm  >nul 2>nul || (echo npm not found in PATH & pause & exit /b 1)
-where python >nul 2>nul || (echo Python not found in PATH & pause & exit /b 1)
 
 if exist package-lock.json (
   set "INSTALL_CMD=npm ci"

--- a/game-server/setup.ps1
+++ b/game-server/setup.ps1
@@ -1,0 +1,44 @@
+Param()
+
+$ErrorActionPreference = 'Stop'
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $scriptDir
+
+function Assert-Command {
+    param (
+        [string]$Command,
+        [string]$Message
+    )
+
+    if (-not (Get-Command $Command -ErrorAction SilentlyContinue)) {
+        Write-Host "[!] $Message"
+        exit 1
+    }
+}
+
+Assert-Command 'node' 'Node.js is required but was not found in PATH.'
+Assert-Command 'npm' 'npm is required but was not found in PATH.'
+
+Write-Host '[*] Installing dependencies with npm ci...'
+npm ci
+if ($LASTEXITCODE -ne 0) {
+    Write-Host '[!] npm ci failed.'
+    exit $LASTEXITCODE
+}
+
+if (-not (Test-Path '.env')) {
+    if (Test-Path '.env.example') {
+        Copy-Item '.env.example' '.env'
+        Write-Host '[*] Created .env from .env.example.'
+    }
+    else {
+        Write-Host '[!] .env.example not found; skipping environment bootstrap.'
+    }
+}
+else {
+    Write-Host '[*] .env already exists; leaving it untouched.'
+}
+
+Write-Host '[*] Starting server with npm start...'
+npm start
+exit $LASTEXITCODE

--- a/game-server/setup_cachyos.sh
+++ b/game-server/setup_cachyos.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "[!] Node.js is required but was not found in PATH." >&2
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "[!] npm is required but was not found in PATH." >&2
+  exit 1
+fi
+
+echo "[*] Installing dependencies with npm ci..."
+npm ci
+
+echo "[*] Ensuring environment file exists..."
+if [ ! -f .env ]; then
+  if [ -f .env.example ]; then
+    cp .env.example .env
+    echo "[*] Created .env from template."
+  else
+    echo "[!] .env.example not found; skipping environment bootstrap." >&2
+  fi
+else
+  echo "[*] .env already present; leaving it untouched."
+fi
+
+echo "[*] Starting server with npm start..."
+exec npm start


### PR DESCRIPTION
## Summary
- replace the legacy connect-session-file dependency with session-file-store and store sessions in a dedicated .sessions directory
- add an example environment file plus README guidance on configuration, dev/prod usage, and security considerations
- provide cross-platform setup scripts and remove obsolete Python checks from existing helper scripts

## Testing
- npm ci *(fails in this environment: 403 Forbidden fetching express-session)*

------
https://chatgpt.com/codex/tasks/task_e_68d923414a4083308f77e38b8d6b59f6