### PR TITLE
Fix lobby join flow to emit match lobby event

### DIFF
--- a/game-server/src/server/gameGateway.js
+++ b/game-server/src/server/gameGateway.js
@@ -112,6 +112,7 @@ class ModularGameServer extends EventEmitter {
                 });
                 setPlayerRoom(room.id);
                 socket.join(room.id);
+                socket.emit('joinedMatchLobby', { room: room.toJSON(), yourId: socket.id });
                 this.io.to(room.id).emit('roomStateUpdate', room.toJSON());
             } catch (error) {
                 this.logger.error('Failed to create game:', error);
@@ -139,6 +140,7 @@ class ModularGameServer extends EventEmitter {
                 });
                 setPlayerRoom(room.id);
                 socket.join(room.id);
+                socket.emit('joinedMatchLobby', { room: room.toJSON(), yourId: socket.id });
                 this.io.to(room.id).emit('roomStateUpdate', room.toJSON());
             } catch (error) {
                 socket.emit('error', error.message);


### PR DESCRIPTION
## Summary
- emit the `joinedMatchLobby` event to the requesting socket when a room is created or joined
- ensure clients immediately receive their room state and identifier so the start menu transitions properly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d929bd4be883309a5604192db3a0c2