### PR TITLE
Handle npm ci/package-lock mismatches on CachyOS scripts

### DIFF
--- a/game-server/README.md
+++ b/game-server/README.md
@@ -34,7 +34,7 @@ This project is a lightweight, self-hosted web server for playing classic multip
     ```
     npm ci
     ```
-    - CachyOS users can run `./install_cachyos.sh` to automatically install Node.js (if needed) and run `npm ci`.
+- CachyOS users can run `./install_cachyos.sh` to automatically install Node.js (if needed) and install project dependencies. The script now falls back to `npm install` if `npm ci` detects an out-of-date lock file so installation succeeds on fresh systems.
 
 ## Running the Server
 
@@ -48,7 +48,7 @@ This project is a lightweight, self-hosted web server for playing classic multip
   npm start
   ```
   The server will listen on `PORT` (defaults to `8081`). Access it at `http://[SERVER-IP-ADDRESS]:8081` or `http://localhost:8081` when running locally.
-- CachyOS users can run `./run_cachyos.sh` to verify dependencies and launch the server automatically.
+- CachyOS users can run `./run_cachyos.sh` to verify dependencies and launch the server automatically. The helper script first tries `npm ci` and automatically retries with `npm install` if the lock file needs to be refreshed.
 
 ## Windows & Linux Shortcuts
 
@@ -56,6 +56,7 @@ This project is a lightweight, self-hosted web server for playing classic multip
 - For a full environment bootstrap, use the cross-platform setup scripts:
   - PowerShell: `./setup.ps1`
   - CachyOS/Linux: `./setup_cachyos.sh`
+    - Automatically retries with `npm install` if `npm ci` fails because the packaged lock file is stale.
 
 ## Security Notes
 

--- a/game-server/install_cachyos.sh
+++ b/game-server/install_cachyos.sh
@@ -24,7 +24,11 @@ need_pkg npm
 
 echo "[*] Installing Node deps via npm ci..."
 if [ ! -d node_modules ]; then
-  npm ci
+  if ! npm ci; then
+    status=$?
+    echo "[!] npm ci failed (exit code $status). Falling back to npm install..." >&2
+    npm install
+  fi
 else
   echo "[*] node_modules exists; skipping npm ci"
 fi

--- a/game-server/run_cachyos.sh
+++ b/game-server/run_cachyos.sh
@@ -24,7 +24,11 @@ echo "[*] NPM version:  $(npm -v)"
 
 if [ -f package-lock.json ]; then
     echo "[*] Installing dependencies with npm ci..."
-    npm ci
+    if ! npm ci; then
+        status=$?
+        echo "[!] npm ci failed (exit code $status). Attempting recovery with npm install..." >&2
+        npm install
+    fi
 else
     echo "[*] Installing dependencies with npm install..."
     npm install

--- a/game-server/setup_cachyos.sh
+++ b/game-server/setup_cachyos.sh
@@ -15,7 +15,11 @@ if ! command -v npm >/dev/null 2>&1; then
 fi
 
 echo "[*] Installing dependencies with npm ci..."
-npm ci
+if ! npm ci; then
+  status=$?
+  echo "[!] npm ci failed (exit code $status). Retrying with npm install to refresh lockfile..." >&2
+  npm install
+fi
 
 echo "[*] Ensuring environment file exists..."
 if [ ! -f .env ]; then


### PR DESCRIPTION
## Summary
- make the CachyOS helper scripts fall back to `npm install` whenever `npm ci` fails so that installation continues even when the committed lock file is stale
- document the new recovery behaviour in the README to guide users during setup

## Testing
- not run (npm registry access is blocked in the execution environment, preventing dependency installation)


------
https://chatgpt.com/codex/tasks/task_e_68d92dda3b048330875a50bef1b8fd0a