### PR TITLE
Adjust setup scripts for targeted installs

### DIFF
--- a/game-server/install_cachyos.sh
+++ b/game-server/install_cachyos.sh
@@ -9,18 +9,8 @@ if ! command -v pacman >/dev/null 2>&1; then
   echo "pacman not found (Arch/CachyOS expected)"; exit 1
 fi
 
-echo "[*] Refreshing package databases..."
-sudo pacman -Syu --noconfirm --needed
-
-need_pkg() {
-  local pkg="$1"
-  if ! pacman -Qi "$pkg" >/dev/null 2>&1; then
-    sudo pacman -S --noconfirm --needed "$pkg"
-  fi
-}
-
-need_pkg nodejs
-need_pkg npm
+echo "[*] Installing Node.js and npm dependencies via pacman..."
+sudo pacman -S --noconfirm --needed nodejs npm
 
 echo "[*] Installing Node deps via npm ci..."
 if [ ! -d node_modules ]; then

--- a/game-server/run_windows.bat
+++ b/game-server/run_windows.bat
@@ -24,20 +24,27 @@ set "TEST_SCRIPT="
 for /f "usebackq tokens=* delims=" %%I in (`npm pkg get scripts.test 2^>nul`) do set "TEST_SCRIPT=%%~I"
 
 if defined TEST_SCRIPT (
-  if /I not "!TEST_SCRIPT!"=="undefined" (
-    echo [*] Running npm test...
-    call npm test
-    if errorlevel 1 (
-      echo [!] Tests failed.
-      pause
-      exit /b 1
-    )
-  ) else (
+  set "TEST_SCRIPT=!TEST_SCRIPT:"=!"
+  if /I "!TEST_SCRIPT!"=="undefined" (
     echo [*] No npm test script found; skipping tests.
+  ) else (
+    if "!TEST_SCRIPT!"=="" (
+      echo [*] No npm test script found; skipping tests.
+    ) else (
+      echo [*] Running npm test...
+      call npm test
+      if errorlevel 1 (
+        echo [!] Tests failed.
+        pause
+        exit /b 1
+      )
+    )
   )
 ) else (
   echo [*] No npm test script found; skipping tests.
 )
+
+if not defined PORT set "PORT=8081"
 
 echo [*] Starting server on :%PORT%
 call npm start

--- a/game-server/setup.ps1
+++ b/game-server/setup.ps1
@@ -20,10 +20,15 @@ Assert-Command 'node' 'Node.js is required but was not found in PATH.'
 Assert-Command 'npm' 'npm is required but was not found in PATH.'
 
 Write-Host '[*] Installing dependencies with npm ci...'
-npm ci
-if ($LASTEXITCODE -ne 0) {
-    Write-Host '[!] npm ci failed.'
-    exit $LASTEXITCODE
+& npm ci
+$ciExitCode = $LASTEXITCODE
+if ($ciExitCode -ne 0) {
+    Write-Host "[!] npm ci failed (exit code $ciExitCode). Retrying with npm install to refresh lockfile..."
+    & npm install
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host '[!] npm install failed.'
+        exit $LASTEXITCODE
+    }
 }
 
 if (-not (Test-Path '.env')) {
@@ -40,5 +45,5 @@ else {
 }
 
 Write-Host '[*] Starting server with npm start...'
-npm start
+& npm start
 exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
- stop install_cachyos.sh from running a full system upgrade and only install nodejs/npm via pacman
- add npm install fallback to setup.ps1, ensure environment file generation, and start server
- improve run_windows.bat test detection and set a default port when undefined

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da185bb264833089447906fe746431