### PR TITLE
Add Ubuntu helper script and document Node.js requirements

### DIFF
--- a/game-server/README.md
+++ b/game-server/README.md
@@ -11,8 +11,48 @@ This project is a lightweight, self-hosted web server for playing classic multip
 
 ## Setup
 
-1.  **Node.js:** Ensure you have Node.js installed on the machine that will act as the server.
-2.  **Clone Repository:** Download or clone this repository to your machine.
+### Node.js requirements
+
+This project targets modern Long-Term Support releases of Node.js. The `package.json` explicitly requires Node 18 or newer:
+
+```json
+{
+  "engines": {
+    "node": ">=18"
+  }
+}
+```
+
+- **Linux (recommended via NVM):**
+  1. Install [NVM](https://github.com/nvm-sh/nvm) and load it into your shell:
+     ```bash
+     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+     export NVM_DIR="$HOME/.nvm"
+     [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+     ```
+  2. Install and activate the latest Node 18 LTS build:
+     ```bash
+     nvm install 18
+     nvm use 18
+     ```
+- **Windows:**
+  - Use [nvm-windows](https://github.com/coreybutler/nvm-windows) to install Node 18+ and switch between versions easily.
+  - Alternatively, install the latest LTS release with Chocolatey:
+    ```powershell
+    choco install nodejs-lts
+    ```
+
+### Required build tools
+
+Sharp (used for image processing) depends on native libraries. Install build tooling before running `npm ci`:
+
+- **Debian/Ubuntu:** `sudo apt-get install build-essential libvips`
+- **Arch/CachyOS:** Use the provided `setup_cachyos.sh` or ensure `base-devel` and `libvips` are available.
+- **Windows:** Install the [Windows Build Tools](https://github.com/felixrieseberg/windows-build-tools) or the "Desktop development with C++" workload from the Visual Studio Build Tools installer.
+
+### Clone the repository
+
+1.  **Clone Repository:** Download or clone this repository to your machine.
 
 ## Configuration
 
@@ -30,11 +70,18 @@ This project is a lightweight, self-hosted web server for playing classic multip
 ## Installation
 
 1. Open a terminal or command prompt and navigate to the `game-server` root directory.
-2. Install the dependencies:
-    ```
+2. Install the dependencies with the lockfile-aware workflow:
+    ```bash
     npm ci
     ```
-- CachyOS users can run `./install_cachyos.sh` to automatically install Node.js (if needed) and install project dependencies. The script now falls back to `npm install` if `npm ci` detects an out-of-date lock file so installation succeeds on fresh systems.
+   - If `npm ci` fails because the packaged lock file is outdated, rerun the installation with:
+     ```bash
+     npm install
+     ```
+3. Create or update the `.env` file as described in the [Configuration](#configuration) section before starting the server.
+
+- Debian/Ubuntu users can run `./run_ubuntu.sh` to install Node.js 18.x, the Sharp build dependencies, project packages, and then start the server automatically.
+- CachyOS users can run `./install_cachyos.sh` to automatically install Node.js (if needed) and install project dependencies. The script falls back to `npm install` if `npm ci` detects an out-of-date lock file so installation succeeds on fresh systems.
 
 ## Running the Server
 
@@ -53,10 +100,19 @@ This project is a lightweight, self-hosted web server for playing classic multip
 ## Windows & Linux Shortcuts
 
 - Windows users can double-click `run_windows.bat` to check for Node.js, install dependencies, and start the server automatically.
+- Debian/Ubuntu users can run `./run_ubuntu.sh` for an end-to-end setup that installs Node.js 18.x, system packages, JavaScript dependencies, and then launches the server.
 - For a full environment bootstrap, use the cross-platform setup scripts:
   - PowerShell: `./setup.ps1`
   - CachyOS/Linux: `./setup_cachyos.sh`
     - Automatically retries with `npm install` if `npm ci` fails because the packaged lock file is stale.
+
+## Maintenance
+
+- Run the helper script to audit and patch dependencies automatically:
+  ```bash
+  ./update_dependencies.sh
+  ```
+  The script executes `npm audit` followed by `npm audit fix`, exiting with a non-zero status if fixes require manual follow-up.
 
 ## Security Notes
 

--- a/game-server/package.json
+++ b/game-server/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "A local multiplayer game server with themed UI",
   "main": "server.js",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",

--- a/game-server/run_ubuntu.sh
+++ b/game-server/run_ubuntu.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+cd "$script_dir"
+
+log() {
+    printf '%s\n' "$*"
+}
+
+abort() {
+    log "[!] $*"
+    exit 1
+}
+
+if ! command -v apt-get >/dev/null 2>&1 && ! command -v apt >/dev/null 2>&1; then
+    abort "This helper requires an APT-based distribution (Debian, Ubuntu, etc.)."
+fi
+
+if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+    if command -v sudo >/dev/null 2>&1; then
+        SUDO="sudo"
+    else
+        abort "Root privileges or sudo are required to install packages."
+    fi
+else
+    SUDO=""
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+    APT_CMD=apt-get
+else
+    APT_CMD=apt
+fi
+
+run_privileged() {
+    if [ -n "$SUDO" ]; then
+        $SUDO "$@"
+    else
+        "$@"
+    fi
+}
+
+log "[*] Updating package index..."
+run_privileged "$APT_CMD" update >/dev/null
+
+install_packages() {
+    if [ "$#" -eq 0 ]; then
+        return 0
+    fi
+    log "[*] Installing packages: $*"
+    run_privileged "$APT_CMD" install -y "$@"
+}
+
+if ! command -v curl >/dev/null 2>&1; then
+    install_packages curl ca-certificates
+fi
+
+ensure_node() {
+    if command -v node >/dev/null 2>&1; then
+        return 0
+    fi
+
+    log "[*] Node.js not found. Installing Node.js 18.x..."
+
+    if command -v curl >/dev/null 2>&1; then
+        if curl -fsSL https://deb.nodesource.com/setup_18.x | run_privileged bash -; then
+            install_packages nodejs
+        else
+            log "[!] NodeSource setup failed. Falling back to the distribution nodejs package."
+            install_packages nodejs
+        fi
+    else
+        log "[!] curl is unavailable; attempting to install distribution-provided nodejs package."
+        install_packages nodejs
+    fi
+}
+
+ensure_node
+
+if ! command -v node >/dev/null 2>&1; then
+    abort "Node.js installation failed."
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+    abort "npm is required but was not installed correctly."
+fi
+
+install_packages build-essential libvips libvips-dev
+
+log "[*] Using node: $(command -v node)"
+log "[*] Node version: $(node -v)"
+log "[*] NPM version:  $(npm -v)"
+
+if [ -f package-lock.json ]; then
+    log "[*] Installing dependencies with npm ci..."
+    if ! npm ci; then
+        status=$?
+        log "[!] npm ci failed (exit code $status). Attempting recovery with npm install..."
+        npm install
+    fi
+else
+    log "[*] Installing dependencies with npm install..."
+    npm install
+fi
+
+start_script=$(npm pkg get scripts.start 2>/dev/null || printf 'undefined')
+case "$start_script" in
+    undefined|"undefined")
+        has_start=false
+        ;;
+    *)
+        has_start=true
+        ;;
+esac
+
+if [ "$has_start" = true ]; then
+    log "[*] Starting via npm start..."
+    npm start
+    exit $?
+fi
+
+entry=""
+for candidate in server.js index.js app.js dist/server.js dist/index.js; do
+    if [ -f "$candidate" ]; then
+        entry=$candidate
+        break
+    fi
+done
+
+if [ -z "$entry" ]; then
+    entry=$(node -e 'try{console.log(require("./package.json").main||"")}catch(e){process.exit(0)}') || entry=""
+fi
+
+if [ -n "$entry" ] && [ -f "$entry" ]; then
+    log "[*] Starting via node $entry ..."
+    exec node "$entry"
+fi
+
+abort "No start script and no entry file found. Add \"start\" to package.json or create server.js."
+

--- a/game-server/update_dependencies.sh
+++ b/game-server/update_dependencies.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+cd "$script_dir"
+
+log() {
+    printf '%s\n' "$*"
+}
+
+abort() {
+    log "[!] $*"
+    exit 1
+}
+
+if ! command -v npm >/dev/null 2>&1; then
+    abort "npm is required to audit dependencies."
+fi
+
+log "[*] Auditing dependencies..."
+if npm audit; then
+    log "[*] Audit completed. Attempting automated fixes..."
+else
+    log "[!] npm audit reported vulnerabilities. Attempting automated fixes..."
+fi
+
+if npm audit fix; then
+    log "[*] npm audit fix completed."
+else
+    status=$?
+    log "[!] npm audit fix exited with status $status. Some issues may require manual intervention."
+    exit "$status"
+fi
+


### PR DESCRIPTION
## Summary
- add a Debian/Ubuntu automation script that installs Node.js 18.x, sharp build dependencies, and starts the server with npm ci fallback logic
- document the minimum Node.js version in package.json and expand the README with installation guidance, build tool requirements, and maintenance steps
- provide an update_dependencies.sh helper to run npm audit followed by npm audit fix

## Testing
- npm ci *(fails: registry returned 403 Forbidden for express-session)*

------
https://chatgpt.com/codex/tasks/task_e_68da1bd4b8b483309e736522fa8fb0e3