### PR TITLE
Improve network info display and accessibility

### DIFF
--- a/game-server/public/index.html
+++ b/game-server/public/index.html
@@ -174,10 +174,8 @@
                 <div class="window-body status-body">
                     <div class="status-indicator online" role="status">Online</div>
                     <div class="status-message" aria-live="polite" role="status">Local multiplayer services are running.</div>
-                    <div class="network-info" aria-live="polite">
-                        <div>IP: <span id="server-ip">Loading…</span></div>
-                        <div>URL: <span id="server-url">Loading…</span></div>
-                        <div>Localhost: <span id="server-local-url">Loading…</span></div>
+                    <div class="network-info" aria-live="polite" role="status">
+                        IP: <span id="server-ip">Loading…</span> • URL: <span id="server-url">Loading…</span>
                     </div>
                 </div>
             </div>

--- a/game-server/public/js/main.js
+++ b/game-server/public/js/main.js
@@ -7,7 +7,6 @@ import { initializeWindowControls } from './ui/windowControls.js';
 async function loadNetworkInfo() {
   const ipElement = document.getElementById('server-ip');
   const urlElement = document.getElementById('server-url');
-  const localUrlElement = document.getElementById('server-local-url');
 
   if (!ipElement || !urlElement) {
     return;
@@ -16,9 +15,6 @@ async function loadNetworkInfo() {
   const setUnknown = () => {
     ipElement.textContent = 'Unknown';
     urlElement.textContent = 'Unknown';
-    if (localUrlElement) {
-      localUrlElement.textContent = 'Unknown';
-    }
   };
 
   try {
@@ -33,13 +29,8 @@ async function loadNetworkInfo() {
     const resolvedPort = Number.isFinite(parsedPort) ? parsedPort : 8081;
 
     const remoteUrl = `http://${resolvedIp}:${resolvedPort}`;
-    const localUrl = `http://localhost:${resolvedPort}`;
-
     ipElement.textContent = resolvedIp;
-    urlElement.textContent = remoteUrl;
-    if (localUrlElement) {
-      localUrlElement.textContent = localUrl;
-    }
+    urlElement.textContent = `${remoteUrl} / http://localhost:${resolvedPort}`;
   } catch (error) {
     console.warn('Unable to load network info.', error);
     setUnknown();

--- a/game-server/public/js/managers/UIManager.js
+++ b/game-server/public/js/managers/UIManager.js
@@ -44,21 +44,30 @@ export class UIManager {
   showView(viewName) {
     const { views = {}, modals = {}, lobby = {} } = this.elements || {};
     Object.values(views || {}).forEach((view) => {
-      if (view) view.classList.add('hidden');
+      if (view && typeof view.classList?.add === 'function') {
+        view.classList.add('hidden');
+      }
     });
+
     const activeView = views?.[viewName];
-    if (activeView) {
+    if (activeView && typeof activeView.classList?.remove === 'function') {
       activeView.classList.remove('hidden');
       this.currentView = viewName;
     } else if (viewName) {
       console.warn(`Requested view "${viewName}" does not exist in the cached elements.`);
     }
-    lobby?.lobbyListContainer?.classList.toggle('hidden', viewName !== 'mainLobby');
-    if (viewName !== 'gameUI' && modals?.gameOver) {
-      if (this.modalManager) {
-        this.modalManager.closeModal(modals.gameOver, { returnFocus: false });
-      } else {
-        modals.gameOver.classList.add('hidden');
+
+    const lobbyContainer = lobby?.lobbyListContainer;
+    if (lobbyContainer && typeof lobbyContainer.classList?.toggle === 'function') {
+      lobbyContainer.classList.toggle('hidden', viewName !== 'mainLobby');
+    }
+
+    const gameOverModal = modals?.gameOver;
+    if (viewName !== 'gameUI' && gameOverModal) {
+      if (this.modalManager && typeof this.modalManager.closeModal === 'function') {
+        this.modalManager.closeModal(gameOverModal, { returnFocus: false });
+      } else if (typeof gameOverModal.classList?.add === 'function') {
+        gameOverModal.classList.add('hidden');
       }
     }
   }

--- a/game-server/public/signup.html
+++ b/game-server/public/signup.html
@@ -166,7 +166,12 @@
           maxlength="32"
           autocomplete="nickname"
           placeholder="Shown to other players"
+          aria-label="Display name"
+          aria-invalid="false"
+          aria-describedby="signup-displayName-error"
+          data-error-id="signup-displayName-error"
         />
+        <span id="signup-displayName-error" class="input-error" role="alert" hidden></span>
       </div>
       <div>
         <label for="signup-password">Password</label>

--- a/game-server/public/style.css
+++ b/game-server/public/style.css
@@ -678,17 +678,18 @@
   .network-info {
     margin-left: auto;
     display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
+    flex-wrap: wrap;
     align-items: flex-end;
+    justify-content: flex-end;
+    gap: var(--space-2);
     font-size: 12px;
     color: var(--win2k-muted);
     text-align: right;
     line-height: 1.4;
-    min-width: 180px;
+    min-width: 200px;
   }
 
-  .network-info div {
+  .network-info span {
     white-space: nowrap;
   }
 

--- a/game-server/run_ubuntu.sh
+++ b/game-server/run_ubuntu.sh
@@ -127,7 +127,7 @@ if [ "$has_start" = true ]; then
 
     trap 'kill "$server_pid" 2>/dev/null || true' INT TERM
 
-    log "[*] Listening on http://$server_ip:$port_value and http://localhost:$port_value"
+    log "Server running at http://$server_ip:$port_value and http://localhost:$port_value"
     log "[*] Press Ctrl+C to stop the server."
 
     wait "$server_pid"

--- a/game-server/run_windows.bat
+++ b/game-server/run_windows.bat
@@ -74,7 +74,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command ^
   "$port = if ($env:PORT) { $env:PORT } else { '8081' }; ^
    $npm = Start-Process npm -ArgumentList 'start' -NoNewWindow -PassThru; ^
    $ip = if ($env:SERVER_IP) { $env:SERVER_IP } else { '127.0.0.1' }; ^
-   Write-Host ('[*] Listening on http://{0}:{1} and http://localhost:{1}' -f $ip, $port); ^
+   Write-Host ('Server running at http://{0}:{1} and http://localhost:{1}' -f $ip, $port); ^
    Write-Host '[*] Press Ctrl+C to stop the server.'; ^
    $npm.WaitForExit(); ^
    exit $npm.ExitCode"


### PR DESCRIPTION
## Summary
- show the server IP and both LAN/localhost URLs in the footer with refreshed styling and fetch logic
- guard UI view switching, enhance the signup form’s accessibility messaging, and keep modal focus handling reliable
- print the resolved server URLs after helper scripts launch npm start

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da305ae520833098c9f7e90f391f46