### PR TITLE
Add Tic-Tac-Toe plugin and surface in UI

### DIFF
--- a/game-server/public/js/managers/UIManager.js
+++ b/game-server/public/js/managers/UIManager.js
@@ -104,6 +104,12 @@ export class UIManager {
     this.lobbyUI.bindLobbyControls(options);
   }
 
+  updateAvailableGames(availableGames) {
+    if (typeof this.lobbyUI.updateAvailableGames === 'function') {
+      this.lobbyUI.updateAvailableGames(availableGames);
+    }
+  }
+
   updateMatchLobby(room, myPlayerId) {
     this.lobbyUI.updateMatchLobby(room, myPlayerId, (player, fallback) =>
       this.derivePlayerLabel(player, fallback)

--- a/game-server/public/js/ui/lobby.js
+++ b/game-server/public/js/ui/lobby.js
@@ -3,6 +3,8 @@ import { validateRoomCode } from '../utils/validation.js';
 export function createLobbyUI(elements, toast, modalManager) {
   const { lobby, matchLobby, modals } = elements;
   let joinHandler = null;
+  let createGameHandler = null;
+  let cachedAvailableGames = [];
 
   function setRoomJoinHandler(handler) {
     joinHandler = handler;
@@ -98,7 +100,14 @@ export function createLobbyUI(elements, toast, modalManager) {
       onJoinGame?.(validation.value);
     });
 
-    populateGameSelection(availableGames, onCreateGame);
+    createGameHandler = onCreateGame;
+    cachedAvailableGames = Array.isArray(availableGames) ? availableGames : [];
+    populateGameSelection(cachedAvailableGames, createGameHandler);
+  }
+
+  function updateAvailableGames(availableGames = []) {
+    cachedAvailableGames = Array.isArray(availableGames) ? availableGames : [];
+    populateGameSelection(cachedAvailableGames, createGameHandler);
   }
 
   function updateMatchLobby(room, myPlayerId, derivePlayerLabel) {
@@ -158,6 +167,7 @@ export function createLobbyUI(elements, toast, modalManager) {
     setRoomJoinHandler,
     renderRoomList,
     bindLobbyControls,
+    updateAvailableGames,
     updateMatchLobby
   };
 }

--- a/game-server/src/core/gameRoomManager.js
+++ b/game-server/src/core/gameRoomManager.js
@@ -103,6 +103,13 @@ class GameRoomManager extends EventEmitter {
             await this.repository?.save?.(roomId, payload.state);
             this.emit('gameState', payload);
         });
+        const forwardRoundEnd = (payload) => {
+            this.emit('roundEnd', payload);
+        };
+        synchronizer.on('roundEnd', forwardRoundEnd);
+        room.once('gameDetached', () => {
+            synchronizer.off('roundEnd', forwardRoundEnd);
+        });
         this.emit('gameStarted', { roomId, state: gameInstance.getState() });
         return { room, gameInstance };
     }

--- a/game-server/src/core/stateSynchronizer.js
+++ b/game-server/src/core/stateSynchronizer.js
@@ -16,11 +16,21 @@ class StateSynchronizer extends EventEmitter {
             });
         };
         this.stateManager.on('stateChanged', this.listener);
+        this.roundEndListener = (payload) => {
+            this.emit('roundEnd', {
+                roomId: this.roomId,
+                ...payload,
+            });
+        };
+        this.stateManager.on('roundEnd', this.roundEndListener);
     }
 
     dispose() {
         if (this.listener) {
             this.stateManager.off('stateChanged', this.listener);
+        }
+        if (this.roundEndListener) {
+            this.stateManager.off('roundEnd', this.roundEndListener);
         }
     }
 }

--- a/game-server/src/plugins/tictactoe/index.js
+++ b/game-server/src/plugins/tictactoe/index.js
@@ -2,103 +2,260 @@
 
 const { buildGameInstance } = require('../../core');
 
+const BOARD_SIZE = 3;
+const PLAYER_MARKERS = ['X', 'O'];
+
 class PlaceMarkStrategy {
     execute({ state, playerManager, playerId, payload }) {
         if (!playerManager.hasPlayer(playerId)) {
             return { error: 'Player not part of this game.' };
         }
-        const playerOrder = playerManager.list().map(p => p.id);
-        const turn = state.turn || playerOrder[0];
-        if (playerId !== turn) {
-            return { error: 'Not your turn.' };
+        if (state.isRoundComplete) {
+            return { error: 'Round already finished. Reset to play again.' };
         }
+        if (!state.turnOrder || state.turnOrder.length < 2) {
+            return { error: 'Game is not ready yet.' };
+        }
+        if (state.turn !== playerId) {
+            return { error: 'It is not your turn.' };
+        }
+
         const { row, col } = payload || {};
-        if (![0, 1, 2].includes(row) || ![0, 1, 2].includes(col)) {
-            return { error: 'Invalid move position.' };
+        if (!isValidCoordinate(row) || !isValidCoordinate(col)) {
+            return { error: 'Invalid board position.' };
         }
-        if (state.board[row][col] !== null) {
+        if (state.board?.[row]?.[col] !== null) {
             return { error: 'Cell already occupied.' };
         }
-        const symbolIndex = playerOrder.indexOf(playerId);
-        const symbol = symbolIndex === 0 ? 'X' : 'O';
+
+        const marker = state.players?.[playerId]?.marker;
+        if (!marker) {
+            return { error: 'No marker assigned to this player.' };
+        }
+
+        const originalState = cloneState(state);
+        const nextState = cloneState(state);
+        nextState.board[row][col] = marker;
+        nextState.lastMove = { playerId, marker, row, col, placedAt: Date.now() };
+
+        const victory = detectWinner(nextState.board);
+        if (victory) {
+            nextState.isRoundComplete = true;
+            nextState.winner = findPlayerByMarker(nextState.players, victory.marker);
+            nextState.roundOutcome = {
+                result: 'win',
+                playerId: nextState.winner,
+                marker: victory.marker,
+                winningLine: victory.line,
+            };
+            nextState.turn = null;
+        } else if (isBoardFull(nextState.board)) {
+            nextState.isRoundComplete = true;
+            nextState.winner = null;
+            nextState.roundOutcome = { result: 'draw' };
+            nextState.turn = null;
+        } else {
+            nextState.turn = getNextTurn(state.turnOrder, playerId);
+            nextState.roundOutcome = null;
+        }
+
         return {
-            apply(current) {
-                const next = JSON.parse(JSON.stringify(current));
-                next.board[row][col] = symbol;
-                next.turn = playerOrder[(symbolIndex + 1) % playerOrder.length];
-                const winner = checkWinner(next.board);
-                if (winner) {
-                    next.winner = playerId;
-                    next.isComplete = true;
-                } else if (next.board.flat().every(cell => cell !== null)) {
-                    next.isComplete = true;
-                }
-                return next;
+            apply() {
+                return nextState;
             },
             getUndo() {
-                return () => {
-                    const reverted = JSON.parse(JSON.stringify(state));
-                    return { state: reverted };
-                };
+                return () => ({ state: originalState });
             },
         };
     }
 }
 
-function checkWinner(board) {
-    const lines = [
-        [board[0][0], board[0][1], board[0][2]],
-        [board[1][0], board[1][1], board[1][2]],
-        [board[2][0], board[2][1], board[2][2]],
-        [board[0][0], board[1][0], board[2][0]],
-        [board[0][1], board[1][1], board[2][1]],
-        [board[0][2], board[1][2], board[2][2]],
-        [board[0][0], board[1][1], board[2][2]],
-        [board[0][2], board[1][1], board[2][0]],
-    ];
-    return lines.some(line => line[0] && line.every(cell => cell === line[0]));
+class ResetRoundStrategy {
+    execute({ state, playerManager }) {
+        if (!state.isRoundComplete) {
+            return { error: 'Round is still in progress.' };
+        }
+        if (!state.turnOrder || state.turnOrder.length < 2) {
+            return { error: 'Not enough players to reset the round.' };
+        }
+        if (playerManager.list().length < state.turnOrder.length) {
+            return { error: 'All players must be present to reset the round.' };
+        }
+
+        const originalState = cloneState(state);
+        const nextState = cloneState(state);
+        nextState.board = createEmptyBoard();
+        nextState.isRoundComplete = false;
+        nextState.winner = null;
+        nextState.round += 1;
+        nextState.roundOutcome = null;
+        nextState.lastMove = null;
+        nextState.turn = getStartingPlayerForRound(state.turnOrder, nextState.round);
+
+        return {
+            apply() {
+                return nextState;
+            },
+            getUndo() {
+                return () => ({ state: originalState });
+            },
+        };
+    }
+}
+
+function createEmptyBoard() {
+    return Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(null));
+}
+
+function isValidCoordinate(value) {
+    return Number.isInteger(value) && value >= 0 && value < BOARD_SIZE;
+}
+
+function cloneState(state = {}) {
+    return JSON.parse(JSON.stringify(state));
+}
+
+function detectWinner(board) {
+    const lines = [];
+    for (let i = 0; i < BOARD_SIZE; i += 1) {
+        lines.push({ line: `row-${i}`, cells: [board[i][0], board[i][1], board[i][2]] });
+        lines.push({ line: `col-${i}`, cells: [board[0][i], board[1][i], board[2][i]] });
+    }
+    lines.push({ line: 'diag-main', cells: [board[0][0], board[1][1], board[2][2]] });
+    lines.push({ line: 'diag-anti', cells: [board[0][2], board[1][1], board[2][0]] });
+
+    for (const entry of lines) {
+        if (entry.cells[0] && entry.cells.every(cell => cell === entry.cells[0])) {
+            return { marker: entry.cells[0], line: entry.line };
+        }
+    }
+    return null;
+}
+
+function isBoardFull(board) {
+    return board.every(row => row.every(cell => cell !== null));
+}
+
+function findPlayerByMarker(players = {}, marker) {
+    return Object.keys(players).find(id => players[id]?.marker === marker) || null;
+}
+
+function getNextTurn(order, currentPlayerId) {
+    const index = order.indexOf(currentPlayerId);
+    if (index === -1) {
+        return order[0] || null;
+    }
+    return order[(index + 1) % order.length] || null;
+}
+
+function getStartingPlayerForRound(order, roundNumber) {
+    if (!order.length) {
+        return null;
+    }
+    const offset = (roundNumber - 1) % order.length;
+    return order[offset];
+}
+
+function initializeGameState(game, participants) {
+    const players = Array.isArray(participants) ? participants : [];
+    const assignments = {};
+    const turnOrder = [];
+
+    players.slice(0, PLAYER_MARKERS.length).forEach((participant, index) => {
+        const marker = PLAYER_MARKERS[index];
+        const added = game.playerManager.addPlayer({
+            id: participant.id,
+            displayName: participant.displayName || participant.username || `Player ${index + 1}`,
+            isReady: true,
+            metadata: { marker },
+        });
+        turnOrder.push(added.id);
+        assignments[added.id] = {
+            id: added.id,
+            marker,
+            displayName: added.displayName,
+        };
+    });
+
+    const snapshot = game.stateManager.snapshot().state;
+    const nextState = {
+        ...snapshot,
+        board: createEmptyBoard(),
+        turnOrder,
+        players: assignments,
+        turn: turnOrder[0] || null,
+        isRoundComplete: false,
+        winner: null,
+        round: 1,
+        roundOutcome: null,
+        lastMove: null,
+    };
+
+    game.stateManager.replace(nextState, { system: 'tic-tac-toe:init' });
+}
+
+function attachRoundEndEmitter(game, roomId) {
+    let lastEmittedRound = 0;
+    const handler = ({ current }) => {
+        const { state } = current;
+        if (!state.isRoundComplete) {
+            return;
+        }
+        if (state.round <= lastEmittedRound) {
+            return;
+        }
+        lastEmittedRound = state.round;
+        const winnerId = state.winner || null;
+        const winnerMarker = winnerId ? state.players?.[winnerId]?.marker || null : null;
+        const eventPayload = {
+            roomId,
+            round: state.round,
+            board: state.board.map(row => row.slice()),
+            winnerId,
+            winnerMarker,
+            outcome: state.roundOutcome || null,
+        };
+        game.stateManager.emit('roundEnd', eventPayload);
+    };
+    game.stateManager.on('stateChanged', handler);
 }
 
 module.exports = {
     register(registry) {
-        const definition = registry.register({
-            id: 'tictactoe',
-            name: 'Tic Tac Toe',
+        return registry.register({
+            id: 'tic-tac-toe',
+            name: 'Tic-Tac-Toe',
             minPlayers: 2,
             maxPlayers: 2,
             version: '1.0.0',
-            create({ roomId, players }) {
+            create({ roomId, players = [] }) {
                 const game = buildGameInstance({
-                    id: 'tictactoe',
+                    id: 'tic-tac-toe',
                     minPlayers: 2,
                     maxPlayers: 2,
                     initialState: {
                         roomId,
-                        board: [
-                            [null, null, null],
-                            [null, null, null],
-                            [null, null, null],
-                        ],
-                        turn: players?.[0]?.id || null,
-                        isComplete: false,
+                        board: createEmptyBoard(),
+                        turn: null,
+                        turnOrder: [],
+                        players: {},
+                        round: 1,
+                        isRoundComplete: false,
                         winner: null,
+                        roundOutcome: null,
+                        lastMove: null,
                     },
                     strategies: {
                         placeMark: new PlaceMarkStrategy(),
+                        resetRound: new ResetRoundStrategy(),
                     },
                 });
-                if (Array.isArray(players)) {
-                    for (const participant of players) {
-                        game.playerManager.addPlayer({
-                            id: participant.id,
-                            displayName: participant.displayName,
-                            isReady: true,
-                        });
-                    }
-                }
+
+                initializeGameState(game, players);
+                attachRoundEndEmitter(game, roomId);
+
                 return game;
             },
         });
-        return definition;
     },
 };

--- a/game-server/src/server/gameGateway.js
+++ b/game-server/src/server/gameGateway.js
@@ -83,6 +83,12 @@ class ModularGameServer extends EventEmitter {
                 context,
             });
         });
+        this.roomManager.on('roundEnd', ({ roomId, ...event }) => {
+            if (!roomId) {
+                return;
+            }
+            this.io.to(roomId).emit('roundEnd', event);
+        });
     }
 
     attachSocket(socket, { getPlayer, setPlayerRoom, clearPlayerRoom }) {

--- a/game-server/tests/runAll.js
+++ b/game-server/tests/runAll.js
@@ -49,8 +49,8 @@ test('PluginManager loads TicTacToe and Checkers plugins', async () => {
     const registry = new GameRegistry();
     const manager = new PluginManager({ registry, logger: createLogger() });
     await manager.loadFromDirectory(path.join(__dirname, '..', 'src', 'plugins'));
-    const game = registry.get('tictactoe');
-    assert.ok(game, 'tictactoe plugin should register');
+    const game = registry.get('tic-tac-toe');
+    assert.ok(game, 'tic-tac-toe plugin should register');
     assert.strictEqual(game.minPlayers, 2);
     const checkers = registry.get('checkers');
     assert.ok(checkers, 'checkers plugin should register');
@@ -78,7 +78,7 @@ test('GameRoomManager creates rooms and plays TicTacToe', async () => {
     const repository = new InMemoryGameRepository();
     const manager = new GameRoomManager({ gameFactory: factory, repository });
 
-    const room = manager.createRoom({ hostId: 'host', gameId: 'tictactoe', metadata: { mode: 'lan' } });
+    const room = manager.createRoom({ hostId: 'host', gameId: 'tic-tac-toe', metadata: { mode: 'lan' } });
     await manager.joinRoom(room.id, { id: 'host', displayName: 'Host', isReady: true });
     await manager.joinRoom(room.id, { id: 'guest', displayName: 'Guest', isReady: true });
     manager.startGame(room.id);
@@ -97,7 +97,7 @@ test('GameRoomManager undo restores previous state', async () => {
     const repository = new InMemoryGameRepository();
     const manager = new GameRoomManager({ gameFactory: factory, repository });
 
-    const room = manager.createRoom({ hostId: 'host', gameId: 'tictactoe', metadata: { mode: 'lan' } });
+    const room = manager.createRoom({ hostId: 'host', gameId: 'tic-tac-toe', metadata: { mode: 'lan' } });
     await manager.joinRoom(room.id, { id: 'host', displayName: 'Host', isReady: true });
     await manager.joinRoom(room.id, { id: 'guest', displayName: 'Guest', isReady: true });
     manager.startGame(room.id);


### PR DESCRIPTION
## Summary
- add a Tic-Tac-Toe game plugin with turn enforcement, win/draw detection, and round reset support
- forward round end events through the server so clients receive Tic-Tac-Toe results
- update the lobby UI to list Tic-Tac-Toe and consume dynamic game lists from the server

## Testing
- node game-server/tests/runAll.js

------
https://chatgpt.com/codex/tasks/task_e_68da467b93408330a6360c3d62e6f2b0