### PR TITLE
Enforce secure secret handling at startup

### DIFF
--- a/game-server/.env.example
+++ b/game-server/.env.example
@@ -1,4 +1,9 @@
-SESSION_SECRET=change_me
-JWT_SECRET=change_me
-GUEST_SESSION_SECRET=change_me
+# Environment configuration for HomeGame game server
+# Generate strong secrets (>=32 characters, high entropy) and keep them private.
+# Example: openssl rand -base64 48
+SESSION_SECRET=
+JWT_SECRET=
+GUEST_SESSION_SECRET=
+
+# Comma-separated list of allowed origins for CORS
 ALLOWED_ORIGINS=http://localhost:3000


### PR DESCRIPTION
## Summary
- validate authentication-related secrets at startup and abort when insecure defaults are detected
- generate cryptographically strong fallback secrets for development environments and warn operators
- document secure secret expectations in the sample environment file

## Testing
- npm run lint *(fails: npm audit 403 Forbidden while contacting registry)*

------
https://chatgpt.com/codex/tasks/task_e_68da5590b6bc833087916becde0f730b