### PR TITLE
Fix socket rate limiter key generator to handle missing handshake data

### DIFF
--- a/game-server/src/security/rateLimiter.js
+++ b/game-server/src/security/rateLimiter.js
@@ -71,7 +71,13 @@ function createHttpRateLimiter({
     };
 }
 
-function createSocketRateLimiter({ windowMs, max, keyGenerator = (socket) => socket.handshake.address || socket.id, onLimit } = {}) {
+function createSocketRateLimiter({ windowMs, max, keyGenerator = (socket) => {
+    // Safely access nested properties with optional chaining
+    const address = socket?.handshake?.address
+        || socket?.request?.connection?.remoteAddress
+        || socket?.conn?.remoteAddress;
+    return address || socket?.id || 'unknown';
+}, onLimit } = {}) {
     const limiter = new SlidingWindowRateLimiter({ windowMs, max });
     return function socketRateLimiter(packet, next) {
         const socket = this; // eslint-disable-line no-invalid-this


### PR DESCRIPTION
## Summary
- make the socket rate limiter key generator resilient to missing handshake information
- fall back to multiple potential sources for the client address and default to `unknown`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da6f8cf168833083bc65b9043d6942