### PR TITLE
Add null guard for socket key generation in rate limiter

### DIFF
--- a/game-server/src/security/rateLimiter.js
+++ b/game-server/src/security/rateLimiter.js
@@ -81,7 +81,7 @@ function createSocketRateLimiter({ windowMs, max, keyGenerator = (socket) => {
     const limiter = new SlidingWindowRateLimiter({ windowMs, max });
     return function socketRateLimiter(packet, next) {
         const socket = this; // eslint-disable-line no-invalid-this
-        const key = keyGenerator(socket, packet);
+        const key = socket ? keyGenerator(socket, packet) : 'unknown';
         if (limiter.allow(key)) {
             return next();
         }


### PR DESCRIPTION
## Summary
- ensure the socket rate limiter falls back to an 'unknown' key if the socket context is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da70d793d48330856452817fe3e6df