### PR TITLE
Fix room code sanitization and simplify CachyOS setup

### DIFF
--- a/game-server/install_cachyos.sh
+++ b/game-server/install_cachyos.sh
@@ -79,9 +79,6 @@ else
   sudo pacman -S --noconfirm --needed nodejs npm
 fi
 
-npm_install_cmd=(npm ci)
-npm_fallback_cmd=(npm install)
-
 if [ -d node_modules ]; then
   if (( EUID == 0 )) && [[ -n "${SUDO_USER:-}" ]] && command -v sudo >/dev/null 2>&1; then
     if ! sudo -H -u "$SUDO_USER" -- test -w node_modules; then
@@ -94,16 +91,7 @@ if [ -d node_modules ]; then
   fi
 fi
 
-if [ ! -d node_modules ]; then
-  echo "[*] Installing Node deps via npm ci..."
-  if ! run_as_invoking_user "${npm_install_cmd[@]}"; then
-    status=$?
-    echo "[!] npm ci failed (exit code $status). Falling back to npm install..." >&2
-    run_as_invoking_user "${npm_fallback_cmd[@]}"
-  fi
-else
-  echo "[*] node_modules exists; refreshing dependencies with npm install"
-  run_as_invoking_user "${npm_fallback_cmd[@]}"
-fi
+echo "[*] Installing Node.js dependencies with npm install..."
+run_as_invoking_user npm install
 
 echo "[*] Done."

--- a/game-server/setup_cachyos.sh
+++ b/game-server/setup_cachyos.sh
@@ -14,17 +14,13 @@ if ! command -v npm >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "[*] Installing dependencies with npm ci..."
+echo "[*] Installing dependencies with npm install..."
 if [ -d node_modules ] && [ ! -w node_modules ]; then
   echo "[!] node_modules exists but is not writable by $(whoami). Please fix permissions (e.g., chown) before continuing." >&2
   exit 1
 fi
 
-if ! npm ci; then
-  status=$?
-  echo "[!] npm ci failed (exit code $status). Retrying with npm install to refresh lockfile..." >&2
-  npm install
-fi
+npm install
 
 echo "[*] Ensuring environment file exists..."
 if [ ! -f .env ]; then

--- a/game-server/tests/runAll.js
+++ b/game-server/tests/runAll.js
@@ -14,7 +14,7 @@ const {
 } = require('../src/core');
 const { createProfileService } = require('../src/profile/profileService');
 const { processAvatar } = require('../src/profile/avatarProcessor');
-const { validateDisplayNameInput } = require('../src/security/validators');
+const { sanitizeRoomCode, validateDisplayNameInput } = require('../src/security/validators');
 
 const SAMPLE_PNG = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWNgYGD4DwABBAEAH0UBPwAAAABJRU5ErkJggg==', 'base64');
 
@@ -180,6 +180,15 @@ test('Avatar processor normalizes output images', async () => {
     assert.ok(result.outputWidth <= 32);
     assert.ok(result.outputHeight <= 32);
     assert.ok(result.buffer.length > 0, 'Processed avatar should have data');
+});
+
+test('sanitizeRoomCode accepts legacy and server-generated codes', () => {
+    assert.strictEqual(sanitizeRoomCode('ABC123'), 'ABC123');
+    assert.strictEqual(sanitizeRoomCode('abc123'), 'ABC123', 'Manual codes should normalize to uppercase');
+    assert.strictEqual(sanitizeRoomCode('lan_75c40e28'), 'lan_75c40e28');
+    assert.strictEqual(sanitizeRoomCode('LAN_75C40E28'), 'lan_75c40e28', 'Server codes should normalize to lowercase prefix and hex');
+    assert.strictEqual(sanitizeRoomCode('LAN75C40E28'), 'lan_75c40e28', 'Codes without separator should still map to generated format');
+    assert.strictEqual(sanitizeRoomCode('??'), null);
 });
 
 (async () => {


### PR DESCRIPTION
## Summary
- normalize server-generated room IDs during validation so LAN rooms can be rejoined reliably
- add regression tests covering the expanded room code sanitization rules
- switch CachyOS install/setup scripts to rely on `npm install` without falling back from `npm ci`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da80d774dc83308672ca09cf6dc68b