### PR TITLE
Show all open rooms in lobby

### DIFF
--- a/game-server/src/server/gameGateway.js
+++ b/game-server/src/server/gameGateway.js
@@ -302,10 +302,11 @@ class ModularGameServer extends EventEmitter {
     _serializeRooms() {
         const summary = {};
         for (const room of this.roomManager.rooms.values()) {
-            if (room.metadata.mode === 'lan' && room.playerManager.players.size < room.playerManager.maxPlayers) {
+            if (room.playerManager.players.size < room.playerManager.maxPlayers) {
                 summary[room.id] = {
                     roomId: room.id,
                     gameType: room.gameId,
+                    mode: room.metadata.mode,
                     playerCount: room.playerManager.players.size,
                     maxPlayers: room.playerManager.maxPlayers,
                 };


### PR DESCRIPTION
## Summary
- update the room serialization to list any non-full room regardless of mode
- include the room mode in the serialized lobby data so clients know how the room was created

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dac59952548330bed06715eefe2557