### PR TITLE
Improve CachyOS setup scripts and remove artifact file

### DIFF
--- a/game-server/install_cachyos.sh
+++ b/game-server/install_cachyos.sh
@@ -91,7 +91,16 @@ if [ -d node_modules ]; then
   fi
 fi
 
-echo "[*] Installing Node.js dependencies with npm install..."
-run_as_invoking_user npm install
+if [ -f package-lock.json ]; then
+  echo "[*] Installing Node.js dependencies with npm ci..."
+  if ! run_as_invoking_user npm ci; then
+    status=$?
+    echo "[!] npm ci failed (exit code $status). Retrying with npm install..." >&2
+    run_as_invoking_user npm install
+  fi
+else
+  echo "[*] Installing Node.js dependencies with npm install..."
+  run_as_invoking_user npm install
+fi
 
 echo "[*] Done."

--- a/game-server/setup_cachyos.sh
+++ b/game-server/setup_cachyos.sh
@@ -14,13 +14,22 @@ if ! command -v npm >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "[*] Installing dependencies with npm install..."
 if [ -d node_modules ] && [ ! -w node_modules ]; then
   echo "[!] node_modules exists but is not writable by $(whoami). Please fix permissions (e.g., chown) before continuing." >&2
   exit 1
 fi
 
-npm install
+if [ -f package-lock.json ]; then
+  echo "[*] Installing dependencies with npm ci..."
+  if ! npm ci; then
+    status=$?
+    echo "[!] npm ci failed (exit code $status). Retrying with npm install..." >&2
+    npm install
+  fi
+else
+  echo "[*] Installing dependencies with npm install..."
+  npm install
+fi
 
 echo "[*] Ensuring environment file exists..."
 if [ ! -f .env ]; then

--- a/test.txt
+++ b/test.txt
@@ -1,3 +1,0 @@
-Test
-
-test


### PR DESCRIPTION
## Summary
- ensure the CachyOS installation scripts prefer `npm ci` and gracefully fall back to `npm install`
- remove an unused `test.txt` artifact from the repository root

## Testing
- node tests/runAll.js

------
https://chatgpt.com/codex/tasks/task_e_68dac781f1888330965769f236faadbf