### PR TITLE
Handle npm ci fallback and improve lobby broadcasts

### DIFF
--- a/game-server/install_cachyos.sh
+++ b/game-server/install_cachyos.sh
@@ -95,7 +95,8 @@ if [ -f package-lock.json ]; then
   echo "[*] Installing Node.js dependencies with npm ci..."
   if ! run_as_invoking_user npm ci; then
     status=$?
-    echo "[!] npm ci failed (exit code $status). Retrying with npm install..." >&2
+    echo "[!] npm ci failed with exit code $status. The lockfile may be out of sync." >&2
+    echo "[*] Falling back to npm install to regenerate dependencies and the lockfile..."
     run_as_invoking_user npm install
   fi
 else

--- a/game-server/server.js
+++ b/game-server/server.js
@@ -1250,10 +1250,11 @@ function getOpenRooms() {
         const playerCount = room.playerManager.players.size;
         console.log('Room:', room.id, 'Players:', playerCount, 'Max:', room.playerManager.maxPlayers, 'Mode:', room.metadata.mode);
 
-        if (room.metadata.mode === 'lan' && playerCount < room.playerManager.maxPlayers) {
+        if (playerCount < room.playerManager.maxPlayers) {
             openRooms[room.id] = {
                 roomId: room.id,
                 gameType: room.gameId,
+                mode: room.metadata.mode,
                 playerCount,
                 maxPlayers: room.playerManager.maxPlayers,
                 hostId: room.hostId,

--- a/game-server/src/server/gameGateway.js
+++ b/game-server/src/server/gameGateway.js
@@ -69,10 +69,16 @@ class ModularGameServer extends EventEmitter {
         this.roomManager.on('gameStarted', ({ roomId, state }) => {
             const room = this.roomManager.getRoom(roomId);
             if (room) {
+                const gameState = state?.state || {};
+                const players = Array.isArray(gameState.players)
+                    ? gameState.players
+                    : room.playerManager.list();
+                const turn = gameState.turnColor || gameState.turn || null;
                 this.io.to(roomId).emit('gameStart', {
                     gameState: state.state,
-                    players: room.playerManager.list(),
+                    players,
                     gameId: room.gameId,
+                    turn,
                 });
             }
             updateMetrics();


### PR DESCRIPTION
## Summary
- fallback to npm install in the CachyOS install script when npm ci fails
- emit game start events with player color assignments and the active turn from the game state
- list all non-full rooms regardless of mode when broadcasting open rooms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dacc88beec833092dfe5afbc2754f5