### PR TITLE
Fix Checkers turn validation to use turnColor

### DIFF
--- a/game-server/public/js/components/CheckersScene.js
+++ b/game-server/public/js/components/CheckersScene.js
@@ -145,7 +145,8 @@ export class CheckersScene {
       return;
     }
 
-    if (this.gameState.turn !== this.myColor) {
+    if (this.gameState.turnColor !== this.myColor) {
+      // It’s not your turn if the current turn colour doesn’t match your colour.
       return;
     }
 


### PR DESCRIPTION
## Summary
- update the Checkers client to verify turns using the game state's `turnColor`
- add inline comment clarifying the intent of the updated turn check

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dad01f5b3c8330800f1ce865887c4e