### PR TITLE
Fix checkers move submission and move lobby identity editor to overlay

### DIFF
--- a/game-server/public/index.html
+++ b/game-server/public/index.html
@@ -59,21 +59,9 @@
 
                     <p id="name-greeting" class="name-greeting">Welcome, <span id="player-name-preview">Guest</span>!</p>
 
-                    <label for="displayNameInput" class="sr-only">Quick display name</label>
-                    <div class="name-row">
-                        <input id="displayNameInput" class="input-field" placeholder="Your display name" maxlength="24" autocomplete="name">
-                        <button id="saveDisplayNameBtn" class="btn" type="button">Save Name</button>
-                    </div>
-
-                    <div class="window-section classic-raised" aria-labelledby="identity-title">
-                        <h2 id="identity-title">Identity</h2>
-                        <p>Choose the name that will appear in match lobbies and scoreboards.</p>
-                        <label for="player-name-input" class="sr-only">Display name</label>
-                        <div class="name-input-row">
-                            <input type="text" id="player-name-input" class="input-field" placeholder="Enter your display name..." maxlength="24" autocomplete="name">
-                            <button id="save-name-btn" class="btn" type="button">Save Name</button>
-                        </div>
-                        <p id="name-status" class="name-status hidden" role="status"></p>
+                    <div class="identity-cta" aria-live="polite">
+                        <p class="identity-cta__description">Keep your profile tidy by managing your display name from a dedicated window.</p>
+                        <button id="open-identity-overlay-btn" class="btn btn-secondary" type="button">Edit Display Name</button>
                     </div>
 
                     <div class="window-section classic-raised" aria-labelledby="p2p-title">
@@ -192,6 +180,27 @@
                 <div id="game-selection-list" class="selection-list"></div>
                 <div class="modal-actions">
                     <button id="close-modal-btn" class="btn" type="button">Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="identity-overlay" class="modal-overlay hidden identity-overlay" role="dialog" aria-modal="true" aria-labelledby="identity-overlay-title" tabindex="-1">
+        <div class="modal-content classic-raised identity-modal">
+            <div class="title-bar">
+                <span class="title-bar-text" id="identity-overlay-title">Player Identity</span>
+                <div class="title-bar-controls">
+                    <button type="button" class="title-bar-btn" id="close-identity-overlay-btn" aria-label="Close identity window">×</button>
+                </div>
+            </div>
+            <div class="modal-body identity-modal__body">
+                <p>Choose the name that will appear in match lobbies and scoreboards.</p>
+                <label for="identity-display-name" class="sr-only">Display name</label>
+                <input type="text" id="identity-display-name" class="input-field" placeholder="Enter your display name..." maxlength="24" autocomplete="name">
+                <p id="identity-status" class="name-status hidden" role="status"></p>
+                <div class="modal-actions identity-modal__actions">
+                    <button id="identity-save-btn" class="btn btn-primary" type="button">Save Name</button>
+                    <button id="identity-cancel-btn" class="btn" type="button">Cancel</button>
                 </div>
             </div>
         </div>

--- a/game-server/public/js/components/CheckersScene.js
+++ b/game-server/public/js/components/CheckersScene.js
@@ -156,9 +156,29 @@ export class CheckersScene {
       (this.myColor === 'black' && BLACK_PIECES.has(pieceAtClick));
 
     if (this.selectedPiece) {
-      const from = { x: this.selectedPiece.x, y: this.selectedPiece.y };
-      const to = { x: gridX, y: gridY };
-      this.socket?.emit('movePiece', { from, to });
+      if (this.selectedPiece.x === gridX && this.selectedPiece.y === gridY) {
+        this.selectedPiece = null;
+        this.render();
+        return;
+      }
+
+      const from = {
+        row: this.selectedPiece.y,
+        col: this.selectedPiece.x,
+      };
+      const destination = {
+        row: gridY,
+        col: gridX,
+      };
+
+      this.socket?.emit('submitMove', {
+        type: 'movePiece',
+        payload: {
+          from,
+          to: destination,
+          sequence: [destination],
+        },
+      });
       this.selectedPiece = null;
       this.render();
       return;

--- a/game-server/public/js/ui/elements.js
+++ b/game-server/public/js/ui/elements.js
@@ -8,7 +8,8 @@ export function cacheElements() {
     modals: {
       createGame: document.getElementById('create-game-modal'),
       gameOver: document.getElementById('game-over-message'),
-      profilePrompt: document.getElementById('profile-prompt-modal')
+      profilePrompt: document.getElementById('profile-prompt-modal'),
+      identityEditor: document.getElementById('identity-overlay')
     },
     lobby: {
       roomList: document.getElementById('room-list'),
@@ -29,12 +30,14 @@ export function cacheElements() {
       startGameButton: document.getElementById('start-game-btn')
     },
     identity: {
-      quickInput: document.getElementById('displayNameInput'),
-      quickSaveButton: document.getElementById('saveDisplayNameBtn'),
-      input: document.getElementById('player-name-input'),
-      saveButton: document.getElementById('save-name-btn'),
+      overlay: document.getElementById('identity-overlay'),
+      openButton: document.getElementById('open-identity-overlay-btn'),
+      closeButton: document.getElementById('close-identity-overlay-btn'),
+      cancelButton: document.getElementById('identity-cancel-btn'),
+      input: document.getElementById('identity-display-name'),
+      saveButton: document.getElementById('identity-save-btn'),
       preview: document.getElementById('player-name-preview'),
-      status: document.getElementById('name-status')
+      status: document.getElementById('identity-status')
     },
     profile: {
       corner: document.getElementById('profile-corner'),

--- a/game-server/public/style.css
+++ b/game-server/public/style.css
@@ -320,6 +320,21 @@
     margin: 0;
   }
 
+  .identity-cta {
+    display: grid;
+    gap: var(--space-3);
+    align-items: start;
+    background: var(--surface-elevated);
+    border: 2px inset var(--win2k-control-face);
+    padding: var(--space-4);
+    border-radius: var(--radius-sm);
+  }
+
+  .identity-cta__description {
+    margin: 0;
+    color: var(--win2k-muted);
+  }
+
   .profile-corner {
     position: fixed;
     top: 72px;
@@ -717,6 +732,13 @@
     contain: layout paint;
   }
 
+  .identity-overlay {
+    align-items: flex-start;
+    justify-content: flex-end;
+    padding: var(--space-6);
+    background: rgba(0, 0, 0, 0.3);
+  }
+
   .modal-overlay.prompt-modal {
     background: rgba(0, 0, 0, 0.55);
   }
@@ -730,6 +752,19 @@
   .modal-body {
     padding: var(--space-4);
     display: grid;
+    gap: var(--space-3);
+  }
+
+  .identity-modal {
+    max-width: 420px;
+  }
+
+  .identity-modal__body {
+    gap: var(--space-3);
+  }
+
+  .identity-modal__actions {
+    justify-content: flex-end;
     gap: var(--space-3);
   }
 


### PR DESCRIPTION
## Summary
- send checkers move commands through `submitMove` with row/column coordinates so turns advance correctly
- move the display name editor out of the lobby into a dedicated overlay window and update related bindings
- polish styling for the new identity overlay and tidy lobby controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db469f7ad88330a3c30a852bab13e9