### PR TITLE
Add queued locking for profile store writes

### DIFF
--- a/game-server/package-lock.json
+++ b/game-server/package-lock.json
@@ -11,6 +11,7 @@
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "ioredis": "^5.3.2",
+        "proper-lockfile": "^4.1.2",
         "session-file-store": "^1.5.0",
         "sharp": "^0.33.2",
         "socket.io": "^4.7.2"

--- a/game-server/package.json
+++ b/game-server/package.json
@@ -19,6 +19,7 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "ioredis": "^5.3.2",
+    "proper-lockfile": "^4.1.2",
     "session-file-store": "^1.5.0",
     "sharp": "^0.33.2",
     "socket.io": "^4.7.2"

--- a/game-server/tests/runAll.js
+++ b/game-server/tests/runAll.js
@@ -151,8 +151,8 @@ test('ProfileService enforces display name uniqueness', async () => {
     });
     service.initialize();
     try {
-        service.upsert('player1', { username: 'player1', displayName: 'Hero', passwordHash: 'hash' });
-        service.upsert('player2', { username: 'player2', displayName: 'Champion', passwordHash: 'hash' });
+        await service.upsert('player1', { username: 'player1', displayName: 'Hero', passwordHash: 'hash' });
+        await service.upsert('player2', { username: 'player2', displayName: 'Champion', passwordHash: 'hash' });
 
         const conflict = service.ensureDisplayNameAvailability('Hero', 'player2');
         assert.strictEqual(conflict, 'player1');


### PR DESCRIPTION
## Summary
- add a queued, file-locking implementation for profile store writes to avoid race conditions
- make profile mutations asynchronous and await them in server routes and helpers
- add the proper-lockfile dependency and update tests to match the async APIs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db5e67cff88330ab578c924aa4bc81