### PR TITLE
Add null safety checks to checkers scene

### DIFF
--- a/game-server/public/js/components/CheckersScene.js
+++ b/game-server/public/js/components/CheckersScene.js
@@ -126,7 +126,15 @@ export class CheckersScene {
   }
 
   handleBoardClick(event) {
-    if (!this.canvas || !this.gameState) return;
+    if (!this.canvas || !this.gameState || !this.gameState.board) {
+      console.warn('Board click ignored: game state not ready');
+      return;
+    }
+
+    if (!this.gameState.turnColor || !this.myColor) {
+      console.warn('Board click ignored: turn state invalid');
+      return;
+    }
 
     const rect = this.canvas.getBoundingClientRect();
     const scaleX = this.canvas.width / rect.width;
@@ -191,6 +199,11 @@ export class CheckersScene {
   }
 
   updateGameState(newGameState) {
+    if (!newGameState || typeof newGameState !== 'object') {
+      console.error('Invalid game state update received');
+      return;
+    }
+
     this.gameState = newGameState;
     if (!this.gameState?.board) {
       this.selectedPiece = null;


### PR DESCRIPTION
## Summary
- add null checks in the checkers board click handler to guard against missing game state data
- validate incoming game state updates before applying them and reset selection when board data is absent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db732252a48330b820c3b5e25c8cd8