### PR TITLE
Add persistence to password rate limiting

### DIFF
--- a/game-server/.gitignore
+++ b/game-server/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 data/sessions.json
+data/password-attempts.json
 .sessions/


### PR DESCRIPTION
## Summary
- add a password rate limiter that persists attempt counts to disk and restores them on startup
- ensure the generated password attempt store is ignored by version control

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68db7ad89c388330806182d0654e6763