### PR TITLE
Invalidate guest tokens after promotion

### DIFF
--- a/game-server/server.js
+++ b/game-server/server.js
@@ -1580,12 +1580,17 @@ function transferGuestSession(req, res) {
         return null;
     }
 
+    // Clear the guest cookie immediately
     res.clearCookie(GUEST_COOKIE_NAME, {
         httpOnly: true,
         sameSite: 'lax',
         secure: COOKIE_SECURE,
         path: '/',
     });
+
+    // Invalidate the token in the manager
+    guestSessionManager.invalidateToken(req.cookies?.[GUEST_COOKIE_NAME]);
+
     req.guestSession = null;
     return promoted;
 }


### PR DESCRIPTION
## Summary
- clear the guest cookie and invalidate its token when promoting a guest session
- track invalidated guest tokens and discard them on lookup
- periodically clear the invalidated token cache and clean it up on shutdown

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db800879ac83309bfd9c9aa8cf41d8