### PR TITLE
Upgrade multer dependency and fix CSRF token cleanup

### DIFF
--- a/game-server/package-lock.json
+++ b/game-server/package-lock.json
@@ -11,7 +11,7 @@
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "ioredis": "^5.3.2",
-        "multer": "^1.4.5-lts.1",
+        "multer": "^2.0.0",
         "proper-lockfile": "^4.1.2",
         "session-file-store": "^1.5.0",
         "sharp": "^0.33.2",

--- a/game-server/package.json
+++ b/game-server/package.json
@@ -20,7 +20,7 @@
     "express-session": "^1.17.3",
     "express-validator": "^7.0.1",
     "ioredis": "^5.3.2",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.0.0",
     "proper-lockfile": "^4.1.2",
     "session-file-store": "^1.5.0",
     "sharp": "^0.33.2",

--- a/game-server/server.js
+++ b/game-server/server.js
@@ -324,6 +324,12 @@ class CsrfTokenManager {
         }
     }
 
+    revoke(sessionId) {
+        if (sessionId) {
+            this.tokens.delete(sessionId);
+        }
+    }
+
     destroy() {
         clearInterval(this.cleanupInterval);
         this.tokens.clear();
@@ -821,9 +827,7 @@ app.post('/login', authLimiter, csrfMiddleware, async (req, res, next) => {
 
 app.post('/logout', csrfMiddleware, (req, res) => {
     const sessionId = req.sessionID;
-    if (sessionId) {
-        csrfTokens.delete(sessionId);
-    }
+    csrfTokenManager.revoke(sessionId);
 
     clearAuthCookies(res, { secure: COOKIE_SECURE });
 
@@ -1523,7 +1527,7 @@ async function establishSession(req, res, usernameKey, onSuccess) {
             }
 
             if (previousSessionId) {
-                csrfTokens.delete(previousSessionId);
+                csrfTokenManager.revoke(previousSessionId);
             }
 
             req.session.username = usernameKey;


### PR DESCRIPTION
## Summary
- bump multer to the 2.x line to address the security advisory for 1.x
- replace remaining references to the removed csrfTokens map with the CsrfTokenManager so session teardown works again

## Testing
- not run (npm install is blocked from accessing the public npm registry in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68db8da50a4c8330a1f3408f57160bc4